### PR TITLE
Update enrollment program durations to match actual schedule

### DIFF
--- a/src/components/forms/EnrollmentForm.tsx
+++ b/src/components/forms/EnrollmentForm.tsx
@@ -27,12 +27,12 @@ const programs = [
   {
     id: 'the-rose',
     title: 'The Rose',
-    subtitle: 'Foundation Program -- 8 weeks',
+    subtitle: 'Rose Meditation Level 1, 2 & 3 -- 2 days',
   },
   {
     id: 'the-rose-aura-1',
     title: 'The Rose + Aura 1',
-    subtitle: 'Advanced Immersion -- 12 weeks',
+    subtitle: 'Complete Immersion -- 11 days',
   },
 ];
 


### PR DESCRIPTION
The Rose: 2 days (was incorrectly listed as 8 weeks)
The Rose + Aura 1: 11 days (was incorrectly listed as 12 weeks)
Also updated subtitles to match program data source.

https://claude.ai/code/session_01AaBUebPAgVKgpJ9nWez6dn