### PR TITLE
Update continue buttons to use warm Rose Clay color

### DIFF
--- a/src/components/forms/ContributionForm.tsx
+++ b/src/components/forms/ContributionForm.tsx
@@ -160,9 +160,9 @@ export function ContributionForm({ tiers, onSubmit, className }: ContributionFor
         whileTap={selectedTier ? { scale: 0.98 } : undefined}
         className={cn(
           'w-full rounded-xl px-6 py-3 font-medium',
-          'bg-[var(--color-accent)] text-[var(--color-accent-foreground)]',
+          'bg-[var(--color-rose-clay)] text-[var(--color-foreground-on-rose)]',
           'transition-all duration-200',
-          'hover:bg-[var(--color-accent-hover)]',
+          'hover:bg-[var(--color-rose-600)]',
           'disabled:cursor-not-allowed disabled:opacity-50'
         )}
       >

--- a/src/components/forms/EnrollmentForm.tsx
+++ b/src/components/forms/EnrollmentForm.tsx
@@ -142,9 +142,9 @@ export function EnrollmentForm({ onSubmit, className }: EnrollmentFormProps) {
         whileTap={isValid ? { scale: 0.98 } : undefined}
         className={cn(
           'w-full rounded-xl px-6 py-3 font-medium',
-          'bg-[var(--color-accent)] text-[var(--color-accent-foreground)]',
+          'bg-[var(--color-rose-clay)] text-[var(--color-foreground-on-rose)]',
           'transition-all duration-200',
-          'hover:bg-[var(--color-accent-hover)]',
+          'hover:bg-[var(--color-rose-600)]',
           'disabled:cursor-not-allowed disabled:opacity-50'
         )}
       >


### PR DESCRIPTION
Replace the neutral dark brown accent (#3B2F2F) with Rose Clay (#9C6F6E)
for a warmer, more on-brand button appearance. Hover state uses Rose-600.

https://claude.ai/code/session_0171Sn5Ua4Nrx3XkMDfyKfno