### PR TITLE
Replace '13 Domains' stat with '50+ Countries' on main page

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -169,7 +169,7 @@ function BrandEssence() {
         >
           <AnimatedStat value="30+" label="Years" delay={0.5} />
           <AnimatedStat value="6,000+" label="Initiated" delay={0.6} />
-          <AnimatedStat value="13" label="Domains" delay={0.7} />
+          <AnimatedStat value="50+" label="Countries" delay={0.7} />
         </motion.div>
       </div>
     </section>


### PR DESCRIPTION
The 13 Coherence Domains is an internal Codex concept that doesn't
communicate much to first-time visitors. Replaced with a global reach
stat that better complements the existing Years and Initiated stats.

https://claude.ai/code/session_01GSHiMtdDc62qGv5u2jFWzZ