### PR TITLE
Update guardian image paths and file formats

### DIFF
--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -31,7 +31,7 @@ export const guardians: Guardian[] = [
     name: 'Angelina Ataide',
     role: 'Founder & Lead Guardian',
     bio: 'Angelina brings over two decades of experience in somatic healing, consciousness research, and transformative education. She is the creator of the ROSES OS methodology and the primary steward of its lineage.',
-    image: '/guardians/angelina.jpg',
+    image: '/images/angel.JPG',
   },
   {
     id: '2',
@@ -52,7 +52,7 @@ export const guardians: Guardian[] = [
     name: 'Peggy Mar',
     role: 'Guardian of Integration',
     bio: 'Peggy specializes in the integration of transformative experiences into daily life. Her expertise in psychology and mindfulness supports participants in grounding their practice.',
-    image: '/guardians/peggy.jpg',
+    image: '/images/peggy.JPG',
   },
 ];
 


### PR DESCRIPTION
## Summary
Updated image file paths and formats for guardian profile pictures to use a new directory structure and standardized file naming conventions.

## Key Changes
- Changed Angelina Ataide's image path from `/guardians/angelina.jpg` to `/images/angel.JPG`
- Changed Peggy Mar's image path from `/guardians/peggy.jpg` to `/images/peggy.JPG`
- Migrated images from `/guardians/` directory to `/images/` directory
- Updated file extensions from lowercase `.jpg` to uppercase `.JPG`

## Implementation Details
- Image files have been reorganized into a centralized `/images/` directory
- File naming convention updated for Angelina's image (shortened from `angelina.jpg` to `angel.JPG`)
- Peggy's image filename remains the same but moved to new directory with updated extension format

https://claude.ai/code/session_01A1BayTL6i5HyV1PjYJJYYj