### PR TITLE
Align guardian photos to top to prevent heads being cut off

### DIFF
--- a/src/components/sections/GuardianCard.tsx
+++ b/src/components/sections/GuardianCard.tsx
@@ -38,7 +38,7 @@ export default function GuardianCard({ guardian, className }: GuardianCardProps)
               alt={guardian.name}
               width={160}
               height={160}
-              className="w-full h-full object-cover"
+              className="w-full h-full object-cover object-top"
             />
           ) : (
             <div className="w-full h-full bg-[var(--color-background-muted)] flex items-center justify-center">


### PR DESCRIPTION
Add object-top to the Image element so the crop focuses on the top of the photo instead of the center.

https://claude.ai/code/session_01A1BayTL6i5HyV1PjYJJYYj