### PR TITLE
Fix BPI lineage: correct names, institutions, and dates across all docs

### DIFF
--- a/docs/brand/brand-dna.md
+++ b/docs/brand/brand-dna.md
@@ -119,16 +119,16 @@ graph LR
 
 ## Origin & Lineage
 
-Aura Reading emerged in the 1960s, in California, channeled by a North American called **Lewis Bostwick**. Founder of the **Berkeley Psychic Institute** and the **Church of the Divine Man**, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.
+Aura Reading emerged in the 1960s, in California, channeled by a North American called **Lewis S. Bostwick**. Founder of the **Berkeley Psychic Institute** and the **Church of the Divine Man**, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.
 
 ### Lineage Transmission
 
-Berkeley Psychic Institute --> **Anastacia Plunk** --> **Angelina Ataide** --> **ROSES OS**
+Berkeley Psychic Institute --> **Anastasia Plunk** --> **Angelina Ataide** --> **ROSES OS**
 
 ```mermaid
 graph TD
-    LB["Lewis Bostwick<br/><i>1960s, California</i>"] --> BPI["Berkeley Psychic Institute<br/>&<br/>Church of the Divine Man"]
-    BPI --> AP["Anastacia Plunk"]
+    LB["Lewis S. Bostwick<br/><i>1960s, California</i>"] --> BPI["Berkeley Psychic Institute<br/>&<br/>Church of the Divine Man"]
+    BPI --> AP["Anastasia Plunk"]
     AP --> AA["Angelina Ataide"]
     AA --> ROS["ROSES OS"]
 

--- a/docs/foundation/roses-os-overview.md
+++ b/docs/foundation/roses-os-overview.md
@@ -128,7 +128,7 @@ The Codex is the foundational reference document for the Roses OS ecosystem. It 
 
 - **Coherence** -- The definition of coherence as inner agreement and wholeness in motion
 - **Sacred Purpose** -- The Rose as a living technology of remembrance, not a metaphor
-- **Origin, Lineage, and Expansion** -- From Louis Bostwick to Angelina Ataide and CELARIS
+- **Origin, Lineage, and Expansion** -- From Lewis S. Bostwick to Angelina Ataide and CELARIS
 - **Etymology and Numerology** -- The meaning encoded in the name Roses OS (11/2)
 - **The Coherence Architecture** -- 13 core domains of coherence restoration
 - **The Path of the Rose** -- Three progressive levels (Rose One, Two, Three) and the Rose Game

--- a/docs/foundation/the-codex.md
+++ b/docs/foundation/the-codex.md
@@ -126,7 +126,7 @@ In that weaving, you are not a follower.
 
 The Rose Meditation did not emerge from theory or invention. It was received through direct transmission, arising from subtle realms of intelligence and delivered into human experience through lived perception.
 
-In the 1960s, this transmission was received by **Louis Bostwick**, who became its first human steward in this era. He carried the frequency with reverence and responsibility, transmitting it to his disciples, **John Bostwick** and **Anastasia Bostwick**, who ensured its continuity with integrity and devotion.
+In the 1960s, this transmission was received by **Lewis S. Bostwick**, who became its first human steward in this era. Founder of the **Berkeley Psychic Institute** and the **Church of the Divine Man**, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity. The lineage was carried forward by **Anastasia Plunk**, who ensured its continuity with integrity and devotion.
 
 Over time, this lineage reached **Angelina Ataide**, founder of **CELARIS** (Centro de Estudos de Leitura de Aura, Reiki, Intuicao e Sonhos).
 

--- a/docs/source-materials/review-wellness-brand-prompt.md
+++ b/docs/source-materials/review-wellness-brand-prompt.md
@@ -36,7 +36,7 @@ There's no evaluation dimension for how the brand DNA aligns with the revenue mo
 
 ### 4. Missing: Lineage & Transmission Ethics
 
-The prompt mentions "founder story" but doesn't address lineage — a critical dimension for brands rooted in channeled, indigenous, or traditional practices. ROSES OS traces its lineage through Lewis Bostwick → Berkeley Psychic Institute → Anastacia Plunk → Angelina Ataide.
+The prompt mentions "founder story" but doesn't address lineage — a critical dimension for brands rooted in channeled, indigenous, or traditional practices. ROSES OS traces its lineage through Lewis S. Bostwick → Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide.
 
 **The prompt should ask:** "Where do these practices come from? How is that acknowledged? Is there appropriation risk?"
 

--- a/docs/training/mdr-teachers-training-manual.md
+++ b/docs/training/mdr-teachers-training-manual.md
@@ -36,11 +36,11 @@ These teachings are part of a living energetic lineage. They invite inner stilln
 
 ## History
 
-Aura Reading emerged in the 1960s, in California, channeled by a North American called **Lewis Bostwick**. Founder of the **Berkeley Psychic Institute** and the **Church of the Divine Man**, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.
+Aura Reading emerged in the 1960s, in California, channeled by a North American called **Lewis S. Bostwick**. Founder of the **Berkeley Psychic Institute** and the **Church of the Divine Man**, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.
 
 ### Lineage
 
-Berkeley Psychic Institute --> **Anastacia Plunk** --> **Angelina Ataide** --> **ROSES OS**
+Berkeley Psychic Institute --> **Anastasia Plunk** --> **Angelina Ataide** --> **ROSES OS**
 
 ---
 

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -233,10 +233,10 @@ export const pathLevels: PathLevel[] = [
 // =============================================================================
 
 export const lineageEntries: LineageEntry[] = [
-  { id: '1', year: '1970s', name: 'Dr. Vernon Bostwick', description: 'Pioneer in consciousness research and somatic integration. Developed foundational breath-awareness protocols.' },
-  { id: '2', year: '1980s', name: 'BPI (Body-Psyche Integration)', description: 'The integration of somatic psychology with meditative practice. Bridge between clinical and contemplative traditions.' },
-  { id: '3', year: '1990s', name: 'James Plunk', description: 'Advanced the breath-body connection into a systematic teaching methodology. Introduced the concept of "remembrance" as a practice.' },
-  { id: '4', year: '2010s', name: 'Angelina Ataide', description: 'Synthesized the lineage teachings into the Rose technology. Created the coherence framework and the ROSES OS methodology.' },
+  { id: '1', year: '1960s', name: 'Lewis S. Bostwick', description: 'Channeled and systematized the techniques and tools of Aura Reading in California. Founder of the Berkeley Psychic Institute and the Church of the Divine Man.' },
+  { id: '2', year: '1960s', name: 'Berkeley Psychic Institute & Church of the Divine Man', description: 'Center for psychic training and transmission of Aura Reading practices. Bridge between the original channeled teachings and the next generation of stewards.' },
+  { id: '3', year: '1980s', name: 'Anastasia Plunk', description: 'Received and carried the Aura Reading and Rose meditation teachings from the Berkeley Psychic Institute, ensuring the continuity and integrity of the lineage.' },
+  { id: '4', year: '2010s', name: 'Angelina Ataide', description: 'Founder of CELARIS. For over thirty years, she has upheld the Rose as a living transmission, initiating more than six thousand individuals into the Rose tradition.' },
   { id: '5', year: '2020s', name: 'ROSES OS', description: 'The platform crystallizes decades of lineage wisdom into an accessible ecosystem for consciousness, remembrance, and coherent living.' },
 ];
 


### PR DESCRIPTION
The lineage data had incorrect/fictionalized names in mock-data.ts
(Dr. Vernon Bostwick, BPI as Body-Psyche Integration, James Plunk)
and inconsistent spellings across source documents. Corrected to the
canonical lineage: Lewis S. Bostwick → Berkeley Psychic Institute →
Anastasia Plunk → Angelina Ataide → ROSES OS.

https://claude.ai/code/session_01DymiUngtZJNJWJzsveE4xv