### PR TITLE
Raise Diego's head position to align with other guardian photos

### DIFF
--- a/src/components/sections/GuardianCard.tsx
+++ b/src/components/sections/GuardianCard.tsx
@@ -39,6 +39,7 @@ export default function GuardianCard({ guardian, className }: GuardianCardProps)
               width={160}
               height={160}
               className="w-full h-full object-cover object-top"
+              style={guardian.imageTransform ? { transform: guardian.imageTransform } : undefined}
             />
           ) : (
             <div className="w-full h-full bg-[var(--color-background-muted)] flex items-center justify-center">

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -39,6 +39,7 @@ export const guardians: Guardian[] = [
     role: 'Guardian of Structure & Architecture',
     bio: 'Diego is the bridge between spirit and structure. With deep roots in spiritual practice, energy work, and community building, he carries the horizontal axis of ROSES OS — developing platforms, systems, and frameworks that harmonize intuition with strategy and build lasting foundations for remembrance.',
     image: '/images/Diegophoto.avif',
+    imageTransform: 'scale(1.15) translateY(-8%)',
   },
   {
     id: '3',

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -15,6 +15,8 @@ export interface Guardian {
   role: string;
   bio: string;
   image: string;
+  /** Optional CSS transform for fine-tuning photo position in circular crop */
+  imageTransform?: string;
 }
 
 /** Program offering */


### PR DESCRIPTION
Diego's photo is square (420x420) while the other guardians have portrait
photos, so object-position had no effect on his image. Added a per-guardian
imageTransform property and applied scale(1.15) translateY(-8%) to Diego's
photo to shift his head upward within the circular crop.

https://claude.ai/code/session_011RXdJoVLxNRHpyJosa5eCo