### PR TITLE
Recrop Diego photo and update Peggy's role title

### DIFF
--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -29,7 +29,7 @@ export const guardians: Guardian[] = [
   {
     id: '1',
     name: 'Angelina Ataíde',
-    role: 'Lead Guardian',
+    role: 'Guardian of Lineage',
     bio: 'A pioneer in Aura Reading education in Brazil and Portugal, Angelina has dedicated over three decades to spiritual development and training aura readers. Her transformative methodology has already trained thousands of students, therapists, and teachers — combining spiritual wisdom with practical techniques as the primary steward of the ROSES OS lineage.',
     image: '/images/angel.JPG',
   },


### PR DESCRIPTION
- Changed Diego's imageTransform from scale(0.85) translateY(5%) to
  scale(1.2) translateY(-8%) so the image fills the circle fully and
  shifts up to show more of his shoulders/body
- Updated Peggy's role from "Guardian of Practice & Methodology" to
  "Guardian of Methodology"

https://claude.ai/code/session_014ak4eSCxcWrRzZbu6dwYpb