### PR TITLE
Deduplicate Rose path content in codex and update Rose Two focus

### DIFF
--- a/docs/foundation/the-codex.md
+++ b/docs/foundation/the-codex.md
@@ -502,12 +502,6 @@ The Rose establishes the foundation. The Aura awakens perception. The Dreams tra
 
 This is not metaphor. It is architecture.
 
-### The Roses Sequence
-
-- **Rose One** is offered freely, meeting each person exactly where they are
-- **Rose Two** integrates remembrance into daily rhythm
-- **Rose Three** opens initiation and increased energetic capacity
-
 From here, two learning rivers unfold:
 
 - **The Aura Path** (Levels 1--4) develops perceptual clarity and precision

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -226,7 +226,7 @@ export const pathLevels: PathLevel[] = [
     title: 'Rose Two',
     subtitle: 'The Deepening',
     description: 'Building on the foundation, Rose Two invites a deeper relationship with the subtle body and energetic awareness. Through daily practice, participants strengthen nervous system coherence, emotional integration, and vibrational clarity, weaving remembrance into the rhythm of everyday life.',
-    focus: ['Energetic awareness', 'Nervous system coherence', 'Advanced breathwork', 'Relational coherence'],
+    focus: ['Energetic awareness', 'Nervous system coherence', 'Emotional integration', 'Relational coherence'],
   },
   {
     id: '3',


### PR DESCRIPTION
Remove the "Roses Sequence" subsection from Section VIII of the codex,
as it duplicated the Rose One/Two/Three descriptions already covered in
Section V ("The Path of the Rose"). Replace "Advanced breathwork" in
Rose Two's focus areas with "Emotional integration" to better align
with the codex's description of Rose Two.

https://claude.ai/code/session_01DckhgjiCVPBAmT3X7aqJRq