### PR TITLE
Fix lineage timeline dates hidden behind bullet dots

### DIFF
--- a/src/components/sections/LineageTimeline.tsx
+++ b/src/components/sections/LineageTimeline.tsx
@@ -102,7 +102,11 @@ export default function LineageTimeline({ entries, className }: LineageTimelineP
               />
 
               {/* Year */}
-              <p className="text-xs font-medium uppercase tracking-[0.15em] text-[#C4A86B] mb-1.5">
+              <p className={cn(
+                "text-xs font-medium uppercase tracking-[0.15em] text-[#C4A86B] mb-1.5",
+                // Desktop: position above the gold line
+                "lg:absolute lg:top-0 lg:left-4",
+              )}>
                 {entry.year}
               </p>
 


### PR DESCRIPTION
Position year labels absolutely above the gold horizontal line on
desktop so they're no longer obscured by the node dots.

https://claude.ai/code/session_01G2sqtcY8dqf32sHP1rn7bb