### PR TITLE
Update color palette and fonts to match brand DNA

### DIFF
--- a/scripts/generate-page-images.ts
+++ b/scripts/generate-page-images.ts
@@ -169,7 +169,7 @@ COLOR PALETTE (ROSES OS brand — use these as accent tones on a white backgroun
 - Rose 400: #D4A09A (lighter warm rose)
 - Rose 300: #E8C4BF (pale blush)
 - Rose 200: #F5E1DD (very soft petal)
-- Gold: #C4A86B (sacred gold accent — use sparingly)
+- Gold: #9E956B (antique olive brass accent — use sparingly)
 - Dark accent: #3B2828 (deep rose-brown, for subtle contrast)
 - Background: pure white or very faint warm cream (#FAFAFA or #FFFFFF)
 `;
@@ -295,7 +295,7 @@ COMPOSITION REQUIREMENTS:
 - CRITICAL: The background MUST be perfectly pure white (#FFFFFF) with ZERO variation. No shadows, no gradients, no grey tones, no vignetting, no ambient occlusion, no drop shadows, no floor shadows, no reflected light on the background. The background must be completely uniform flat white from edge to edge, corner to corner.
 - The subject should be centered or elegantly composed, clearly visible and recognizable
 - Flat, even lighting — no directional shadows cast onto the background
-- Color palette: muted rose tones (#9C6F6E rose-clay, #D4A09A warm rose, #E8C4BF blush, #F5E1DD petal pink), touches of gold (#C4A86B)
+- Color palette: muted rose tones (#9C6F6E rose-clay, #D4A09A warm rose, #E8C4BF blush, #F5E1DD petal pink), touches of gold (#9E956B)
 - Style: photorealistic 3D render or high-end botanical illustration — polished, editorial, Apple-level quality
 - The image should look like it belongs on a pure white webpage where the edges of the image are completely invisible
 - NO text, NO letters, NO words, NO numbers in the image

--- a/src/app/(invitation)/invitation/learn-more/page.tsx
+++ b/src/app/(invitation)/invitation/learn-more/page.tsx
@@ -187,9 +187,9 @@ function AgreementsSection() {
                 className={cn(
                   'flex-shrink-0 flex items-center justify-center',
                   'w-8 h-8 rounded-full',
-                  'bg-[#C4A86B]/10 text-[#C4A86B]',
+                  'bg-[#9E956B]/10 text-[#9E956B]',
                   'font-serif font-semibold text-sm',
-                  'border border-[#C4A86B]/20'
+                  'border border-[#9E956B]/20'
                 )}
               >
                 {i + 1}

--- a/src/app/(site)/community/page.tsx
+++ b/src/app/(site)/community/page.tsx
@@ -121,9 +121,9 @@ export default function CommunityPage() {
                     className={cn(
                       'flex items-center justify-center',
                       'w-8 h-8 rounded-full',
-                      'bg-[#C4A86B]/10 text-[#C4A86B]',
+                      'bg-[#9E956B]/10 text-[#9E956B]',
                       'font-serif font-semibold text-sm',
-                      'border border-[#C4A86B]/20'
+                      'border border-[#9E956B]/20'
                     )}
                   >
                     {i + 1}

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -129,7 +129,7 @@ function BrandEssence() {
     <section ref={ref} className="relative py-24 lg:py-32 bg-[#1A1716] text-white overflow-hidden">
       {/* Rose-gold gradient orb */}
       <div className="absolute top-0 right-0 w-[500px] h-[500px] bg-rose-500/10 rounded-full blur-[150px] pointer-events-none" />
-      <div className="absolute bottom-0 left-0 w-[400px] h-[400px] bg-[#C4A86B]/10 rounded-full blur-[120px] pointer-events-none" />
+      <div className="absolute bottom-0 left-0 w-[400px] h-[400px] bg-[#9E956B]/10 rounded-full blur-[120px] pointer-events-none" />
 
       <div className="container-premium max-w-4xl mx-auto text-center relative z-10">
         <motion.p

--- a/src/app/(site)/the-codex/page.tsx
+++ b/src/app/(site)/the-codex/page.tsx
@@ -159,9 +159,9 @@ function ArchitectureLayers() {
               <span
                 className={cn(
                   'block font-serif text-3xl leading-none',
-                  'text-[#C4A86B]/40 mb-3',
+                  'text-[#9E956B]/40 mb-3',
                   'transition-colors duration-300',
-                  'group-hover:text-[#C4A86B]/70'
+                  'group-hover:text-[#9E956B]/70'
                 )}
               >
                 {String(i + 1).padStart(2, '0')}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,7 +20,7 @@ body {
 @theme inline {
   /* Colors - Warm Neutrals */
   --color-warm-0: #FFFFFF;
-  --color-warm-50: #FAF8F5;
+  --color-warm-50: #F7F5F2;
   --color-warm-100: #F5F0EB;
   --color-warm-200: #E8E0D8;
   --color-warm-300: #D4C8BE;
@@ -28,7 +28,7 @@ body {
   --color-warm-500: #8C7E73;
   --color-warm-600: #6B5F56;
   --color-warm-700: #504540;
-  --color-warm-800: #3B2F2F;
+  --color-warm-800: #3F3E3C;
   --color-warm-900: #2A2020;
   --color-warm-950: #1A1716;
 
@@ -45,14 +45,17 @@ body {
   --color-rose-900: #3B2828;
   --color-rose-950: #2A1C1C;
 
-  /* Brand Accent Colors */
-  --color-gold: #C4A86B;
-  --color-sage: #A3B5A6;
-  --color-lavender: #B8A9C9;
+  /* Brand Accent Colors — from Brand DNA */
+  --color-gold: #9E956B;
+  --color-terracotta: #C4836C;
+  --color-honeyed: #C7AE8C;
+  --color-peach-sand: #EBD6C1;
+  --color-golden-ether: #F5E8E2;
+  --color-cream-veil: #FFF8E7;
 
   /* Status Colors */
   --color-success: #5B9A6F;
-  --color-warning: #C4A86B;
+  --color-warning: #9E956B;
   --color-error: #C0392B;
   --color-info: #6B5F56;
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -84,7 +84,7 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#FAF8F5' },
+    { media: '(prefers-color-scheme: light)', color: '#F7F5F2' },
     { media: '(prefers-color-scheme: dark)', color: '#1A1716' },
   ],
   width: 'device-width',

--- a/src/components/sections/DomainGrid.tsx
+++ b/src/components/sections/DomainGrid.tsx
@@ -81,7 +81,7 @@ export default function DomainGrid({ domains, className }: DomainGridProps) {
                       <span
                         className={cn(
                           'font-serif text-2xl lg:text-3xl leading-none',
-                          'text-[#C4A86B]/50'
+                          'text-[#9E956B]/50'
                         )}
                       >
                         {String(domain.number).padStart(2, '0')}

--- a/src/components/sections/ElevenCapacities.tsx
+++ b/src/components/sections/ElevenCapacities.tsx
@@ -41,10 +41,10 @@ function CapacityItem({ capacity, index }: { capacity: Capacity; index: number }
         className={cn(
           'flex-shrink-0',
           'font-serif text-2xl lg:text-3xl leading-none',
-          'text-[#C4A86B]/50',
+          'text-[#9E956B]/50',
           'w-10 lg:w-12 text-right',
           'transition-colors duration-300',
-          'group-hover:text-[#C4A86B]/80'
+          'group-hover:text-[#9E956B]/80'
         )}
       >
         {String(capacity.number).padStart(2, '0')}

--- a/src/components/sections/LineageTimeline.tsx
+++ b/src/components/sections/LineageTimeline.tsx
@@ -64,7 +64,7 @@ export default function LineageTimeline({ entries, className }: LineageTimelineP
               'left-4 top-0 bottom-0 w-px lg:left-0 lg:top-auto lg:bottom-auto',
               // Desktop: horizontal line centered vertically
               'lg:w-full lg:h-px lg:top-6',
-              'bg-[#C4A86B]'
+              'bg-[#9E956B]'
             )}
           />
 
@@ -95,16 +95,16 @@ export default function LineageTimeline({ entries, className }: LineageTimelineP
                   // Desktop: on the horizontal line
                   'lg:left-4 lg:-top-[5px]',
                   'w-3 h-3 rounded-full',
-                  'bg-[#C4A86B]',
+                  'bg-[#9E956B]',
                   'border-2 border-[var(--color-background)]',
-                  'shadow-[0_0_0_2px_#C4A86B]'
+                  'shadow-[0_0_0_2px_#9E956B]'
                 )}
               />
 
               {/* Year */}
               <p className={cn(
                 "relative z-10",
-                "text-xs font-medium uppercase tracking-[0.15em] text-[#C4A86B] mb-1.5",
+                "text-xs font-medium uppercase tracking-[0.15em] text-[#9E956B] mb-1.5",
                 // Desktop: position above the gold line
                 "lg:absolute lg:top-0 lg:left-4",
               )}>

--- a/src/components/sections/PathLevels.tsx
+++ b/src/components/sections/PathLevels.tsx
@@ -93,11 +93,11 @@ export default function PathLevels({ levels, variant = 'full', className }: Path
                     className={cn(
                       'flex items-center justify-center',
                       'w-8 h-8 rounded-full',
-                      'bg-[#C4A86B]/10 text-[#C4A86B]',
+                      'bg-[#9E956B]/10 text-[#9E956B]',
                       'font-serif font-semibold text-sm',
-                      'border border-[#C4A86B]/20',
+                      'border border-[#9E956B]/20',
                       'transition-colors duration-300',
-                      'group-hover:bg-[#C4A86B]/20'
+                      'group-hover:bg-[#9E956B]/20'
                     )}
                   >
                     {level.level}
@@ -139,7 +139,7 @@ export default function PathLevels({ levels, variant = 'full', className }: Path
                               key={i}
                               className="flex items-start gap-2 text-sm text-[var(--color-foreground-muted)]"
                             >
-                              <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-[#C4A86B]/50 flex-shrink-0" />
+                              <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-[#9E956B]/50 flex-shrink-0" />
                               <span>{item}</span>
                             </li>
                           ))}
@@ -163,7 +163,7 @@ export default function PathLevels({ levels, variant = 'full', className }: Path
                           })
                         }
                         className={cn(
-                          'flex items-center gap-1.5 text-xs text-[#C4A86B] hover:text-[#C4A86B]/80',
+                          'flex items-center gap-1.5 text-xs text-[#9E956B] hover:text-[#9E956B]/80',
                           'transition-colors duration-200 cursor-pointer mt-1'
                         )}
                       >

--- a/src/components/teaching/LevelNav.tsx
+++ b/src/components/teaching/LevelNav.tsx
@@ -84,7 +84,7 @@ export default function LevelNav({ levels, activeLevel, className }: LevelNavPro
                   'absolute bottom-0 left-3 right-3 h-0.5 lg:h-auto',
                   // Desktop: left bar
                   'lg:bottom-auto lg:left-0 lg:top-2 lg:bottom-2 lg:right-auto lg:w-0.5',
-                  'bg-[#C4A86B] rounded-full'
+                  'bg-[#9E956B] rounded-full'
                 )}
                 transition={{
                   type: 'spring',
@@ -100,7 +100,7 @@ export default function LevelNav({ levels, activeLevel, className }: LevelNavPro
                 <span
                   className={cn(
                     'font-serif text-xs',
-                    isActive ? 'text-[#C4A86B]' : 'text-[var(--color-foreground-faint)]'
+                    isActive ? 'text-[#9E956B]' : 'text-[var(--color-foreground-faint)]'
                   )}
                 >
                   {String(level.level).padStart(2, '0')}

--- a/src/components/teaching/TechniqueCard.tsx
+++ b/src/components/teaching/TechniqueCard.tsx
@@ -54,8 +54,8 @@ export default function TechniqueCard({ technique, index = 0, className }: Techn
             'inline-flex items-center',
             'text-[11px] font-medium uppercase tracking-[0.1em]',
             'px-2.5 py-1 rounded-full',
-            'bg-[#C4A86B]/10 text-[#C4A86B]',
-            'border border-[#C4A86B]/20'
+            'bg-[#9E956B]/10 text-[#9E956B]',
+            'border border-[#9E956B]/20'
           )}
         >
           {technique.category}

--- a/src/components/three/RoseCanvas.tsx
+++ b/src/components/three/RoseCanvas.tsx
@@ -66,7 +66,7 @@ function Scene({ mouseRef, reducedMotion, isDark }: RoseCanvasProps) {
 
       {/* Soft gold rim — behind */}
       <pointLight
-        color="#C4A86B"
+        color="#9E956B"
         intensity={isDark ? 0.6 : 1.0}
         distance={20}
         decay={2}

--- a/src/components/three/ShaderSphere.tsx
+++ b/src/components/three/ShaderSphere.tsx
@@ -151,7 +151,7 @@ export default function ShaderSphere({ mouseRef, reducedMotion, isDark }: Shader
         ior={1.4}
         envMapIntensity={isDark ? 1.5 : 2.5}
         specularIntensity={1.0}
-        specularColor={"#C4A86B" as unknown as THREE.Color}
+        specularColor={"#9E956B" as unknown as THREE.Color}
         attenuationColor={"#9C6F6E" as unknown as THREE.Color}
         attenuationDistance={1.5}
         side={THREE.DoubleSide}

--- a/src/components/three/ShaderSphereCanvas.tsx
+++ b/src/components/three/ShaderSphereCanvas.tsx
@@ -37,7 +37,7 @@ function Scene({ mouseRef, reducedMotion, isDark }: ShaderSphereCanvasProps) {
       />
       {/* Gold rim light */}
       <pointLight
-        color="#C4A86B"
+        color="#9E956B"
         intensity={isDark ? 1.2 : 2}
         distance={25}
         decay={2}

--- a/src/components/three/shaders/sphere.frag.ts
+++ b/src/components/three/shaders/sphere.frag.ts
@@ -22,7 +22,7 @@ void main() {
   vec3 roseDeep  = vec3(0.43, 0.29, 0.29);   // Deep Earth #6E4A49
   vec3 roseMid   = vec3(0.61, 0.44, 0.43);    // Rose Clay #9C6F6E
   vec3 roseLight = vec3(0.91, 0.77, 0.75);    // Rose 300 #E8C4BF
-  vec3 goldWarm  = vec3(0.77, 0.66, 0.42);    // Soft Gold #C4A86B
+  vec3 goldWarm  = vec3(0.62, 0.58, 0.42);    // Antique Olive Brass #9E956B
 
   // Caustic-like interior — directional streaks
   float animTime = uTime * mix(0.12, 0.0, uReducedMotion);

--- a/src/components/ui/PageTransition.tsx
+++ b/src/components/ui/PageTransition.tsx
@@ -69,7 +69,7 @@ export function PageTransition() {
     <div
       ref={panelRef}
       aria-hidden="true"
-      className="fixed inset-0 z-[9999] bg-[#1A1716] dark:bg-[#FAF8F5]"
+      className="fixed inset-0 z-[9999] bg-[#1A1716] dark:bg-[#F7F5F2]"
       style={{
         transform: 'translateY(100%)',
         willChange: 'transform',

--- a/src/design-system/theme.css
+++ b/src/design-system/theme.css
@@ -1,7 +1,7 @@
 /**
  * Theme CSS Variables — ROSES OS
  * Warm sacred design system with light/dark mode support
- * Light mode is PRIMARY (#FAF8F5 warm white background)
+ * Light mode is PRIMARY (#F7F5F2 Aura White background)
  */
 
 /* =============================================================================
@@ -13,7 +13,7 @@
 
   /* Warm Neutral Scale */
   --color-warm-0: #FFFFFF;
-  --color-warm-50: #FAF8F5;
+  --color-warm-50: #F7F5F2;
   --color-warm-100: #F5F0EB;
   --color-warm-200: #E8E0D8;
   --color-warm-300: #D4C8BE;
@@ -21,7 +21,7 @@
   --color-warm-500: #8C7E73;
   --color-warm-600: #6B5F56;
   --color-warm-700: #504540;
-  --color-warm-800: #3B2F2F;
+  --color-warm-800: #3F3E3C;
   --color-warm-900: #2A2020;
   --color-warm-950: #1A1716;
 
@@ -38,40 +38,44 @@
   --color-rose-900: #3B2828;
   --color-rose-950: #2A1C1C;
 
-  /* Brand Semantic */
+  /* Brand Semantic — from Brand DNA */
   --color-rose-clay: #9C6F6E;
-  --color-soft-gold: #C4A86B;
-  --color-sage-mist: #A3B5A6;
-  --color-dusty-lavender: #B8A9C9;
-  --color-deep-earth: #3B2F2F;
+  --color-olive-brass: #9E956B;
+  --color-terracotta: #C4836C;
+  --color-honeyed-stone: #C7AE8C;
+  --color-gilded-clay: #A8896D;
+  --color-peach-sand: #EBD6C1;
+  --color-golden-ether: #F5E8E2;
+  --color-cream-veil: #FFF8E7;
+  --color-soft-charcoal: #3F3E3C;
 
   /* Semantic Colors - Light Mode */
-  --color-background: #FFFFFF;
+  --color-background: #F7F5F2;
   --color-background-subtle: #F5F0EB;
   --color-background-muted: #E8E0D8;
   --color-background-elevated: #FFFFFF;
-  --color-background-overlay: rgba(59, 47, 47, 0.5);
+  --color-background-overlay: rgba(63, 62, 60, 0.5);
   --color-background-rose: #FDF8F7;
 
-  --color-foreground: #3B2F2F;
+  --color-foreground: #3F3E3C;
   --color-foreground-subtle: #504540;
   --color-foreground-muted: #6B5F56;
   --color-foreground-faint: #8C7E73;
-  --color-foreground-on-rose: #FFFFFF;
+  --color-foreground-on-rose: #F7F5F2;
 
   --color-border: #E8E0D8;
   --color-border-subtle: #F5F0EB;
   --color-border-strong: #D4C8BE;
 
-  --color-accent: #3B2F2F;
-  --color-accent-foreground: #FAF8F5;
+  --color-accent: #3F3E3C;
+  --color-accent-foreground: #F7F5F2;
   --color-accent-hover: #504540;
   --color-accent-subtle: #F5F0EB;
 
   /* Status Colors */
   --color-success: #5B9A6F;
   --color-success-subtle: #E3F0E7;
-  --color-warning: #C4A86B;
+  --color-warning: #9E956B;
   --color-warning-subtle: #F7F0E0;
   --color-error: #C0392B;
   --color-error-subtle: #F5E3E0;
@@ -79,9 +83,9 @@
   --color-info-subtle: #F5F0EB;
 
   /* Gradients */
-  --gradient-primary: linear-gradient(135deg, #3B2F2F 0%, #1A1716 100%);
-  --gradient-secondary: linear-gradient(135deg, #6B5F56 0%, #3B2F2F 100%);
-  --gradient-subtle: linear-gradient(135deg, #FAF8F5 0%, #F5F0EB 100%);
+  --gradient-primary: linear-gradient(135deg, #3F3E3C 0%, #1A1716 100%);
+  --gradient-secondary: linear-gradient(135deg, #6B5F56 0%, #3F3E3C 100%);
+  --gradient-subtle: linear-gradient(135deg, #F7F5F2 0%, #F5F0EB 100%);
 
   /* Shadows — warm-tinted */
   --shadow-xs: 0 1px 2px 0 rgb(59 47 47 / 0.04);
@@ -92,7 +96,7 @@
   --shadow-2xl: 0 25px 50px -12px rgb(59 47 47 / 0.15);
   --shadow-glass: 0 8px 32px 0 rgb(59 47 47 / 0.06);
   --shadow-rose: 0 4px 16px 0 rgb(156 111 110 / 0.15);
-  --shadow-gold: 0 4px 16px 0 rgb(196 168 107 / 0.15);
+  --shadow-gold: 0 4px 16px 0 rgb(158 149 107 / 0.15);
 
   /* Typography */
   --font-serif: "Cormorant Garamond", Georgia, "Times New Roman", serif;
@@ -156,9 +160,9 @@
   --blur-2xl: 24px;
 
   /* Glass Effect — warm */
-  --glass-background: rgba(250, 248, 245, 0.8);
+  --glass-background: rgba(247, 245, 242, 0.8);
   --glass-border: rgba(232, 224, 216, 0.4);
-  --glass-shadow: 0 8px 32px 0 rgba(59, 47, 47, 0.06);
+  --glass-shadow: 0 8px 32px 0 rgba(63, 62, 60, 0.06);
 
   /* Grain texture opacity */
   --grain-opacity: 0.03;
@@ -175,7 +179,7 @@
   /* Semantic Colors - Dark Mode */
   --color-background: #1A1716;
   --color-background-subtle: #2A2020;
-  --color-background-muted: #3B2F2F;
+  --color-background-muted: #3F3E3C;
   --color-background-elevated: #2A2020;
   --color-background-overlay: rgba(26, 23, 22, 0.7);
   --color-background-rose: #2A1C1C;
@@ -184,9 +188,9 @@
   --color-foreground-subtle: #E8E0D8;
   --color-foreground-muted: #B5A89D;
   --color-foreground-faint: #8C7E73;
-  --color-foreground-on-rose: #FAF8F5;
+  --color-foreground-on-rose: #F7F5F2;
 
-  --color-border: #3B2F2F;
+  --color-border: #3F3E3C;
   --color-border-subtle: #2A2020;
   --color-border-strong: #504540;
 
@@ -197,7 +201,7 @@
 
   /* Status Colors - Dark Mode */
   --color-success-subtle: rgba(91, 154, 111, 0.15);
-  --color-warning-subtle: rgba(196, 168, 107, 0.15);
+  --color-warning-subtle: rgba(158, 149, 107, 0.15);
   --color-error-subtle: rgba(192, 57, 43, 0.15);
   --color-info-subtle: rgba(245, 240, 235, 0.08);
 

--- a/src/design-system/tokens.ts
+++ b/src/design-system/tokens.ts
@@ -1,7 +1,7 @@
 /**
  * Design Tokens — ROSES OS
  * Warm, sacred design system with organic curves and contemplative rhythm
- * Palette: warm whites, rose clay, deep earth, soft gold, sage mist
+ * Palette: aura white, rose clay, soft charcoal, antique olive brass
  */
 
 // =============================================================================
@@ -9,21 +9,23 @@
 // =============================================================================
 
 export const colors = {
-  // Brand Core
+  // Brand Core — from Brand DNA
   brand: {
-    warmWhite: '#FAF8F5',
-    softIvory: '#F5F0EB',
-    mutedStone: '#E8E0D8',
-    roseClay: '#9C6F6E',
-    deepEarth: '#3B2F2F',
-    charcoalVeil: '#2C2C2C',
+    auraWhite: '#F7F5F2',        // Primary background — excellent and neutral
+    creamVeil: '#FFF8E7',        // Soft cream background — warm ivory, gentle and luminous
+    goldenEther: '#F5E8E2',      // Warm blush background — parchment ivory with soft golden cast
+    peachSand: '#EBD6C1',        // Light background — peachy cream, soft warmth
+    honeyedStone: '#C7AE8C',     // Background support — warm golden, architectural, inviting
+    gildedClay: '#A8896D',       // Warm neutral — golden-tan, reads earthy and sun-kissed
+    roseClay: '#9C6F6E',         // Signature color — the human interface layer
+    softCharcoal: '#3F3E3C',     // Body text, navigation, buttons, footer, dark elements
   },
 
-  // Accents
+  // Accents — from Brand DNA
   accent: {
-    softGold: '#C4A86B',
-    sageMist: '#A3B5A6',
-    dustyLavender: '#B8A9C9',
+    antiqueOliveBrass: '#9E956B', // Buttons, highlights, sacred detail — like gold in a temple
+    lightTerracotta: '#C4836C',   // Sun-warmed clay, soft earth — warm, luminous, approachable
+    warmRoseClay: '#9B6A66',      // Dusty mauve tones — clay, terracotta dust, sun-warmed stone
   },
 
   // Rose scale (for field usage)
@@ -44,7 +46,7 @@ export const colors = {
   // Warm neutrals (replacing cold greys)
   warm: {
     0: '#FFFFFF',
-    50: '#FAF8F5',
+    50: '#F7F5F2',
     100: '#F5F0EB',
     200: '#E8E0D8',
     300: '#D4C8BE',
@@ -52,7 +54,7 @@ export const colors = {
     500: '#8C7E73',
     600: '#6B5F56',
     700: '#504540',
-    800: '#3B2F2F',
+    800: '#3F3E3C',
     900: '#2A2020',
     950: '#1A1716',
   },
@@ -78,8 +80,8 @@ export const colors = {
     },
     warning: {
       light: '#FDF8F0',
-      default: '#C4A86B',
-      dark: '#A68D55',
+      default: '#9E956B',
+      dark: '#7D7652',
       subtle: '#F7F0E0',
     },
     error: {
@@ -98,14 +100,14 @@ export const colors = {
 
   // Gradients — warm, organic
   gradients: {
-    primary: 'linear-gradient(135deg, #3B2F2F 0%, #1A1716 100%)',
-    secondary: 'linear-gradient(135deg, #6B5F56 0%, #3B2F2F 100%)',
-    subtle: 'linear-gradient(135deg, #FAF8F5 0%, #F5F0EB 100%)',
+    primary: 'linear-gradient(135deg, #3F3E3C 0%, #1A1716 100%)',
+    secondary: 'linear-gradient(135deg, #6B5F56 0%, #3F3E3C 100%)',
+    subtle: 'linear-gradient(135deg, #F7F5F2 0%, #F5F0EB 100%)',
     dark: 'linear-gradient(135deg, #1A1716 0%, #2A2020 100%)',
-    glass: 'linear-gradient(135deg, rgba(250,248,245,0.1) 0%, rgba(250,248,245,0.03) 100%)',
+    glass: 'linear-gradient(135deg, rgba(247,245,242,0.1) 0%, rgba(247,245,242,0.03) 100%)',
     rose: 'linear-gradient(135deg, #9C6F6E 0%, #6E4A49 100%)',
-    gold: 'linear-gradient(135deg, #C4A86B 0%, #A68D55 100%)',
-    mesh: 'radial-gradient(ellipse 80% 50% at 35% 20%, rgba(156,111,110,0.06) 0px, transparent 50%), radial-gradient(ellipse 60% 40% at 75% 80%, rgba(196,168,107,0.04) 0px, transparent 50%)',
+    gold: 'linear-gradient(135deg, #9E956B 0%, #7D7652 100%)',
+    mesh: 'radial-gradient(ellipse 80% 50% at 35% 20%, rgba(156,111,110,0.06) 0px, transparent 50%), radial-gradient(ellipse 60% 40% at 75% 80%, rgba(158,149,107,0.04) 0px, transparent 50%)',
   },
 } as const;
 
@@ -114,7 +116,7 @@ export const colors = {
 // =============================================================================
 
 export const typography = {
-  // Font families — Cormorant Garamond (display) + Inter (body)
+  // Font families — Cormorant Garamond (sacred headlines) + Inter (modern clarity)
   fonts: {
     serif: 'var(--font-serif, "Cormorant Garamond", Georgia, "Times New Roman", serif)',
     sans: 'var(--font-sans, "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif)',
@@ -246,7 +248,7 @@ export const shadows = {
 
   // Rose & Gold variants
   rose: '0 4px 16px 0 rgb(156 111 110 / 0.15)',
-  gold: '0 4px 16px 0 rgb(196 168 107 / 0.15)',
+  gold: '0 4px 16px 0 rgb(158 149 107 / 0.15)',
 
   // Elevation levels
   elevation1: '0 1px 3px 0 rgb(59 47 47 / 0.05), 0 1px 2px 0 rgb(59 47 47 / 0.03)',


### PR DESCRIPTION
Align the design system with the Brand DNA document specifications:

- Background: #FFFFFF → #F7F5F2 (Aura White)
- Body text: #3B2F2F (Deep Earth) → #3F3E3C (Soft Charcoal)
- Accent: #C4A86B (Soft Gold) → #9E956B (Antique Olive Brass)
- Add brand palette colors: Light Terracotta, Gilded Clay, Honeyed Stone,
  Peach Sand, Golden Ether, Cream Veil
- Replace Sage Mist and Dusty Lavender (not in brand DNA) with brand
  palette colors
- Update all hardcoded #C4A86B references across 14 component files
- Update Three.js shader gold color to match new accent
- Update gradients, shadows, and glass effects for consistency

https://claude.ai/code/session_01JTbuWWfjA3odu5KHqzFiQj