### PR TITLE
Update Enroll Now button to warmer warm-50 shade

### DIFF
--- a/src/app/(invitation)/invitation/learn-more/page.tsx
+++ b/src/app/(invitation)/invitation/learn-more/page.tsx
@@ -240,7 +240,7 @@ function ReadyCTA() {
               href="/enroll"
               className={cn(
                 'inline-flex items-center px-8 py-3.5 rounded-full',
-                'bg-white text-warm-950',
+                'bg-warm-50 text-warm-950',
                 'text-sm font-medium',
                 'hover:bg-warm-100',
                 'transition-colors duration-200'


### PR DESCRIPTION
Change the light Enroll Now button on the learn-more page from
pure white (bg-white) to warm-50 (bg-warm-50) to match the
warmer tone applied to other recently updated buttons.

https://claude.ai/code/session_01KM2LDmDquNJyvmFD8ZZ2y1