### PR TITLE
Hide Aura 4 & 5 from public UI while preserving data

### DIFF
--- a/src/app/(site)/the-codex/page.tsx
+++ b/src/app/(site)/the-codex/page.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import {
   lineageEntries,
   coherenceDomains,
-  pathLevels,
+  visiblePathLevels,
   architectureLayers,
   elevenCapacities,
 } from '@/lib/data';
@@ -212,7 +212,7 @@ export default function TheCodexPage() {
 
       {/* 6. The Path */}
       <SectionLabel>The Path</SectionLabel>
-      <PathLevels levels={pathLevels} variant="full" />
+      <PathLevels levels={visiblePathLevels} variant="full" />
 
       {/* 7. Four Layers of the Architecture */}
       <ArchitectureLayers />

--- a/src/app/(site)/the-rose/page.tsx
+++ b/src/app/(site)/the-rose/page.tsx
@@ -4,7 +4,7 @@ import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { pathLevels, brandQuotes } from '@/lib/data';
+import { visiblePathLevels, brandQuotes } from '@/lib/data';
 
 import PageHero from '@/components/sections/PageHero';
 import PathLevels from '@/components/sections/PathLevels';
@@ -153,7 +153,7 @@ export default function TheRosePage() {
       </RevealSection>
 
       {/* 6. Path Levels */}
-      <PathLevels levels={pathLevels} variant="full" />
+      <PathLevels levels={visiblePathLevels} variant="full" />
 
       {/* 7. Quote */}
       <QuoteBlock

--- a/src/components/sections/PathLevels.tsx
+++ b/src/components/sections/PathLevels.tsx
@@ -39,8 +39,8 @@ const stepVariants = {
   },
 };
 
-// Aura 2–5 are levels 5–8; their descriptions are hidden behind a toggle
-const COLLAPSED_LEVELS = new Set([5, 6, 7, 8]);
+// Aura 2–3 are levels 5–6; their descriptions are hidden behind a toggle
+const COLLAPSED_LEVELS = new Set([5, 6]);
 
 export default function PathLevels({ levels, variant = 'full', className }: PathLevelsProps) {
   const ref = useRef<HTMLElement>(null);

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -14,6 +14,7 @@ export {
   contributionTiers,
   coherenceDomains,
   pathLevels,
+  visiblePathLevels,
   lineageEntries,
   architectureLayers,
   chakras,

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -209,6 +209,8 @@ export const coherenceDomains: CoherenceDomain[] = [
 
 // =============================================================================
 // PATH LEVELS (Rose Meditation 1–3 + Aura 1–5)
+// Full dataset kept for future use. Aura 4 & 5 (levels 7–8) are hidden from
+// the public UI via the visiblePathLevels export below.
 // =============================================================================
 
 export const pathLevels: PathLevel[] = [
@@ -277,6 +279,11 @@ export const pathLevels: PathLevel[] = [
     focus: ['Unified mastery', 'Conscious creation', 'Heart-led expression', 'Full sovereignty'],
   },
 ];
+
+// Aura 4 & 5 (levels 7–8) hidden for now; surface them when ready
+export const visiblePathLevels: PathLevel[] = pathLevels.filter(
+  (l) => l.level <= 6
+);
 
 // =============================================================================
 // LINEAGE


### PR DESCRIPTION
Keep the full pathLevels array (including Aura 4 and Aura 5) in
mock-data.ts for future use. Add a visiblePathLevels export that
filters out levels 7-8. Update the-rose and the-codex pages to
render only the visible levels, and narrow the collapsed-level
toggle set to Aura 2-3 only.

https://claude.ai/code/session_01Fz6DNxvAwm5AACgy6dbsCq