### PR TITLE
Fix Angelina's lineage year from 2005s to 2000s in codex page

### DIFF
--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -292,7 +292,7 @@ export const visiblePathLevels: PathLevel[] = pathLevels.filter(
 export const lineageEntries: LineageEntry[] = [
   { id: '1', year: '1960s', name: 'Lewis S. Bostwick', description: 'Channeled the material of Aura Reading in California. Founder of the Berkeley Psychic Institute and the Church of the Divine Man.' },
   { id: '2', year: '1980s', name: 'Anastasia Plunk', description: 'Received and carried the Aura Reading and Rose meditation teachings from the Berkeley Psychic Institute, ensuring the continuity and integrity of the lineage.' },
-  { id: '3', year: '2005s', name: 'Angelina Ataide', description: 'Systematized the techniques and tools of the Rose and Aura tradition. Founder of CELARIS, formerly Escola da Aura & Sueños. For over thirty years, she has upheld the Rose as a living transmission, initiating more than six thousand individuals into the lineage.' },
+  { id: '3', year: '2000s', name: 'Angelina Ataide', description: 'Systematized the techniques and tools of the Rose and Aura tradition. Founder of CELARIS, formerly Escola da Aura & Sueños. For over thirty years, she has upheld the Rose as a living transmission, initiating more than six thousand individuals into the lineage.' },
   { id: '4', year: '2023', name: 'ROSES OS', description: 'The platform crystallizes decades of lineage wisdom into an accessible ecosystem for consciousness, remembrance, and coherent living.' },
 ];
 


### PR DESCRIPTION
The lineage section in mock-data.ts had "2005s" for Angelina Ataide,
which should be "2000s" to match the codex foundation document.

https://claude.ai/code/session_01GtgjjcMCU74tDFAejM3agj