### PR TITLE
Fix Angelina lineage description and restore Aura 4 & 5 in path section

### DIFF
--- a/src/components/sections/PathLevels.tsx
+++ b/src/components/sections/PathLevels.tsx
@@ -39,8 +39,8 @@ const stepVariants = {
   },
 };
 
-// Aura 2–3 are levels 5–6; their descriptions are hidden behind a toggle
-const COLLAPSED_LEVELS = new Set([5, 6]);
+// Aura 2–5 are levels 5–8; their descriptions are hidden behind a toggle
+const COLLAPSED_LEVELS = new Set([5, 6, 7, 8]);
 
 export default function PathLevels({ levels, variant = 'full', className }: PathLevelsProps) {
   const ref = useRef<HTMLElement>(null);

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -280,10 +280,7 @@ export const pathLevels: PathLevel[] = [
   },
 ];
 
-// Aura 4 & 5 (levels 7–8) hidden for now; surface them when ready
-export const visiblePathLevels: PathLevel[] = pathLevels.filter(
-  (l) => l.level <= 6
-);
+export const visiblePathLevels: PathLevel[] = pathLevels;
 
 // =============================================================================
 // LINEAGE
@@ -292,7 +289,7 @@ export const visiblePathLevels: PathLevel[] = pathLevels.filter(
 export const lineageEntries: LineageEntry[] = [
   { id: '1', year: '1960s', name: 'Lewis S. Bostwick', description: 'Channeled the material of Aura Reading in California. Founder of the Berkeley Psychic Institute and the Church of the Divine Man.' },
   { id: '2', year: '1980s', name: 'Anastasia Plunk', description: 'Received and carried the Aura Reading and Rose meditation teachings from the Berkeley Psychic Institute, ensuring the continuity and integrity of the lineage.' },
-  { id: '3', year: '2000s', name: 'Angelina Ataide', description: 'Systematized the techniques and tools of the Rose and Aura tradition. Founder of CELARIS, formerly Escola da Aura & Sueños. For over thirty years, she has upheld the Rose as a living transmission, initiating more than six thousand individuals into the lineage.' },
+  { id: '3', year: '2000s', name: 'Angelina Ataide', description: 'Founder of CELARIS (Centro de Estudos de Leitura de Aura, Reiki, Intuicao e Sonhos), formerly known as Escola da Aura & Sueños. For more than thirty years, she has upheld and embodied the Rose as a living transmission, initiating more than six thousand individuals into the living field of the Rose.' },
   { id: '4', year: '2023', name: 'ROSES OS', description: 'The platform crystallizes decades of lineage wisdom into an accessible ecosystem for consciousness, remembrance, and coherent living.' },
 ];
 


### PR DESCRIPTION
- Update Angelina's lineage description to match the codex: remove
  incorrect "Systematized the techniques" attribution (that belongs to
  Bostwick) and use the codex wording about founding CELARIS and
  embodying the Rose as a living transmission
- Restore Aura 4 & 5 (levels 7-8) in the visible path levels on both
  the Codex and Rose pages
- Add Aura 4 & 5 to the collapsible toggle set for UI consistency

https://claude.ai/code/session_01HD3VVwALp7Y84s9KoinxwF