### PR TITLE
Recrop Dara bio image to show more of dress

### DIFF
--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -46,6 +46,7 @@ export const guardians: Guardian[] = [
     role: 'Guardian of Community & Programs',
     bio: 'With over a decade walking the Aura Reading path and a background in multiple traditions of self-knowledge, Dara integrates body, mind, and spirit with reverence. She supports the creation and delivery of programs and courses, blending intuitive listening with grounded clarity.',
     image: '/images/dara-new.png',
+    imageTransform: 'translateY(-8%)',
   },
   {
     id: '4',


### PR DESCRIPTION
Add imageTransform translateY(-8%) to shift the circular crop downward,
revealing more of Dara's dress in the guardian card.

https://claude.ai/code/session_01GPxQxBZ6UnD9rpR8ouxhGS