### PR TITLE
Add rose clay alternative style variant for review

### DIFF
--- a/src/app/(invitation)/invitation/learn-more/page.tsx
+++ b/src/app/(invitation)/invitation/learn-more/page.tsx
@@ -219,7 +219,7 @@ function ReadyCTA() {
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
   return (
-    <section ref={ref} className="section-padding bg-[#1E1916] text-white">
+    <section ref={ref} className="section-padding bg-[var(--color-section-dark)] text-white">
       <div className="container-premium">
         <div className="max-w-3xl mx-auto text-center">
           <motion.h2
@@ -240,7 +240,7 @@ function ReadyCTA() {
               href="/enroll"
               className={cn(
                 'inline-flex items-center px-8 py-3.5 rounded-full',
-                'bg-warm-50 text-[#1E1916]',
+                'bg-warm-50 text-[var(--color-section-dark)]',
                 'text-sm font-medium',
                 'hover:bg-warm-100',
                 'transition-colors duration-200'

--- a/src/app/(invitation)/invitation/page.tsx
+++ b/src/app/(invitation)/invitation/page.tsx
@@ -21,7 +21,7 @@ const ease = [0.16, 1, 0.3, 1] as const;
 
 function InvitationHero() {
   return (
-    <section className="relative min-h-[100svh] min-h-screen flex items-center justify-center bg-[#1E1916] text-white overflow-hidden">
+    <section className="relative min-h-[100svh] min-h-screen flex items-center justify-center bg-[var(--color-section-dark)] text-white overflow-hidden">
       {/* Subtle texture */}
       <div
         className="absolute inset-0 opacity-[0.04] pointer-events-none"
@@ -72,7 +72,7 @@ function InvitationHero() {
             href="/invitation/learn-more"
             className={cn(
               'inline-flex items-center gap-2 px-8 py-3.5 rounded-full',
-              'bg-warm-100 text-[#1E1916]',
+              'bg-warm-100 text-[var(--color-section-dark)]',
               'text-sm font-medium',
               'hover:bg-warm-200',
               'transition-colors duration-200'
@@ -151,7 +151,7 @@ function ThreePillars() {
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
   return (
-    <section ref={ref} className="section-padding bg-[#1E1916] text-white">
+    <section ref={ref} className="section-padding bg-[var(--color-section-dark)] text-white">
       <div className="container-premium">
         <motion.p
           initial={{ opacity: 0, y: 20 }}
@@ -370,7 +370,7 @@ function FinalCTA() {
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
   return (
-    <section ref={ref} className="section-padding bg-[#1E1916] text-white">
+    <section ref={ref} className="section-padding bg-[var(--color-section-dark)] text-white">
       <div className="container-premium">
         <div className="max-w-3xl mx-auto text-center">
           <motion.h2
@@ -392,7 +392,7 @@ function FinalCTA() {
               href="/invitation/learn-more"
               className={cn(
                 'px-8 py-3.5 rounded-full',
-                'bg-warm-100 text-[#1E1916]',
+                'bg-warm-100 text-[var(--color-section-dark)]',
                 'text-sm font-medium',
                 'hover:bg-warm-200',
                 'transition-colors duration-200'

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -126,7 +126,7 @@ function BrandEssence() {
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
   return (
-    <section ref={ref} className="relative py-24 lg:py-32 bg-[#1A1716] text-white overflow-hidden">
+    <section ref={ref} className="relative py-24 lg:py-32 bg-[var(--color-section-dark)] text-white overflow-hidden">
       {/* Rose-gold gradient orb */}
       <div className="absolute top-0 right-0 w-[500px] h-[500px] bg-rose-500/10 rounded-full blur-[150px] pointer-events-none" />
       <div className="absolute bottom-0 left-0 w-[400px] h-[400px] bg-[#9E956B]/10 rounded-full blur-[120px] pointer-events-none" />
@@ -406,7 +406,7 @@ function InvitationCTA() {
       className="relative overflow-hidden"
     >
       {/* Dark rose gradient */}
-      <div className="absolute inset-0 bg-gradient-to-br from-[#1A1716] via-rose-950 to-[#1A1716]" />
+      <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-section-dark)] via-rose-950 to-[var(--color-section-dark)]" />
 
       {/* Subtle glow */}
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-rose-500/10 rounded-full blur-[150px] pointer-events-none" />
@@ -417,7 +417,7 @@ function InvitationCTA() {
             initial={{ opacity: 0, scale: 0.8 }}
             animate={isInView ? { opacity: 1, scale: 1 } : {}}
             transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
-            className="mx-auto mb-8 w-16 h-16 rounded-full border border-rose-500/30 flex items-center justify-center overflow-hidden bg-[#1A1716]/80"
+            className="mx-auto mb-8 w-16 h-16 rounded-full border border-rose-500/30 flex items-center justify-center overflow-hidden bg-[var(--color-section-dark)]/80"
           >
             <Image
               src="/rose.png"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,6 +53,9 @@ body {
   --color-golden-ether: #F5E8E2;
   --color-cream-veil: #FFF8E7;
 
+  /* Section Dark — for dark-background sections */
+  --color-section-dark: var(--color-section-dark, #1E1916);
+
   /* Status Colors */
   --color-success: #5B9A6F;
   --color-warning: #9E956B;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -110,6 +110,11 @@ export default function RootLayout({
                 } else {
                   document.documentElement.classList.remove('dark')
                 }
+                // Apply style variant (e.g. rose-clay) before hydration
+                var sv = localStorage.getItem('style-variant');
+                if (sv && sv !== 'default') {
+                  document.documentElement.setAttribute('data-style', sv);
+                }
               } catch (_) {}
             `,
           }}

--- a/src/components/sections/InvitationCTA.tsx
+++ b/src/components/sections/InvitationCTA.tsx
@@ -17,7 +17,7 @@ export default function InvitationCTA({ className }: InvitationCTAProps) {
     <section
       ref={ref}
       className={cn(
-        'bg-[#1E1916] text-white',
+        'bg-[var(--color-section-dark)] text-white',
         className
       )}
     >
@@ -43,7 +43,7 @@ export default function InvitationCTA({ className }: InvitationCTAProps) {
               href="/invitation"
               className={cn(
                 'inline-flex items-center px-8 py-3.5 rounded-full',
-                'bg-warm-50 text-[#1E1916]',
+                'bg-warm-50 text-[var(--color-section-dark)]',
                 'text-sm font-medium',
                 'hover:bg-warm-100',
                 'transition-colors duration-200'

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -30,7 +30,7 @@ export default function Footer() {
   return (
     <footer
       ref={footerRef}
-      className="relative bg-[#1E1916] dark:bg-warm-50 text-warm-300 dark:text-warm-600 overflow-hidden transition-colors duration-200"
+      className="relative bg-[var(--color-section-dark)] dark:bg-warm-50 text-warm-300 dark:text-warm-600 overflow-hidden transition-colors duration-200"
     >
       <div className="container-premium py-6 sm:py-8">
         <motion.div

--- a/src/components/ui/PageTransition.tsx
+++ b/src/components/ui/PageTransition.tsx
@@ -69,7 +69,7 @@ export function PageTransition() {
     <div
       ref={panelRef}
       aria-hidden="true"
-      className="fixed inset-0 z-[9999] bg-[#1A1716] dark:bg-[#F7F5F2]"
+      className="fixed inset-0 z-[9999] bg-[var(--color-section-dark)] dark:bg-[#F7F5F2]"
       style={{
         transform: 'translateY(100%)',
         willChange: 'transform',

--- a/src/components/ui/Preloader.tsx
+++ b/src/components/ui/Preloader.tsx
@@ -76,7 +76,7 @@ export function Preloader() {
   return (
     <div
       ref={panelRef}
-      className="fixed inset-0 z-[10000] bg-[#1A1716]"
+      className="fixed inset-0 z-[10000] bg-[var(--color-section-dark)]"
       aria-hidden="true"
     >
       <div

--- a/src/design-system/theme.css
+++ b/src/design-system/theme.css
@@ -164,6 +164,9 @@
   --glass-border: rgba(232, 224, 216, 0.4);
   --glass-shadow: 0 8px 32px 0 rgba(63, 62, 60, 0.06);
 
+  /* Section Dark — dark-background sections (footer, hero, CTA blocks) */
+  --color-section-dark: #1E1916;
+
   /* Grain texture opacity */
   --grain-opacity: 0.03;
 }
@@ -223,6 +226,70 @@
   --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
 
   --grain-opacity: 0.05;
+}
+
+/* =============================================================================
+   ROSE CLAY STYLE VARIANT
+   ============================================================================= */
+/* Alternative style: dark sections become rich rose clay tones instead of
+   near-black warm browns. Toggle via data-style="rose-clay" on <html>. */
+
+[data-style="rose-clay"] {
+  /* Section dark backgrounds — deep rose replaces near-black */
+  --color-section-dark: #6E4A49;
+
+  /* Foreground — rose-tinted charcoals for body text */
+  --color-foreground: #523737;
+  --color-foreground-subtle: #6E4A49;
+  --color-foreground-muted: #8A5E5D;
+  --color-foreground-faint: #9C6F6E;
+
+  /* Accent — rose clay replaces charcoal */
+  --color-accent: #523737;
+  --color-accent-foreground: #FDF8F7;
+  --color-accent-hover: #6E4A49;
+
+  /* Borders — rose-tinted */
+  --color-border: #F5E1DD;
+  --color-border-subtle: #FAF0EE;
+  --color-border-strong: #E8C4BF;
+
+  /* Gradients — rose clay spectrum */
+  --gradient-primary: linear-gradient(135deg, #9C6F6E 0%, #523737 100%);
+  --gradient-secondary: linear-gradient(135deg, #8A5E5D 0%, #6E4A49 100%);
+
+  /* Info status — rose-shifted */
+  --color-info: #8A5E5D;
+
+  /* Soft charcoal → rose dark */
+  --color-soft-charcoal: #523737;
+}
+
+/* Rose Clay + Dark Mode combined */
+[data-style="rose-clay"].dark,
+[data-style="rose-clay"] [data-theme="dark"] {
+  --color-section-dark: #3B2828;
+
+  --color-background: #2A1C1C;
+  --color-background-subtle: #3B2828;
+  --color-background-muted: #523737;
+  --color-background-elevated: #3B2828;
+  --color-background-rose: #3B2828;
+
+  --color-foreground: #F5E1DD;
+  --color-foreground-subtle: #E8C4BF;
+  --color-foreground-muted: #D4A09A;
+  --color-foreground-faint: #9C6F6E;
+
+  --color-border: #523737;
+  --color-border-subtle: #3B2828;
+  --color-border-strong: #6E4A49;
+
+  --color-accent: #F5E1DD;
+  --color-accent-foreground: #2A1C1C;
+  --color-accent-hover: #E8C4BF;
+
+  --gradient-subtle: linear-gradient(135deg, #3B2828 0%, #2A1C1C 100%);
 }
 
 /* =============================================================================


### PR DESCRIPTION
Introduces a toggleable `data-style="rose-clay"` theme variant that
replaces all dark brown/black section backgrounds (#1E1916, #1A1716)
with rich rose clay tones (#6E4A49). Also shifts foreground text,
accents, borders, and gradients to rose-tinted values for cohesion.

Changes:
- Add `--color-section-dark` CSS variable and `[data-style="rose-clay"]`
  variant in theme.css with full light + dark mode support
- Replace all hardcoded dark hex backgrounds in components with
  `var(--color-section-dark)` for theme responsiveness
- Extend ThemeProvider with styleVariant/setStyleVariant/toggleStyleVariant
- Add flash-prevention script in layout.tsx for style variant

To activate: call `toggleStyleVariant()` from useTheme(), or set
`localStorage.setItem('style-variant', 'rose-clay')` and reload.

https://claude.ai/code/session_01JUEyCkCENpVFcLmQ6AZfEr