### PR TITLE
Resize Dara bio photo to show head and shoulders

### DIFF
--- a/src/components/sections/GuardianCard.tsx
+++ b/src/components/sections/GuardianCard.tsx
@@ -39,7 +39,21 @@ export default function GuardianCard({ guardian, className }: GuardianCardProps)
               width={160}
               height={160}
               className="w-full h-full object-cover object-top"
-              style={guardian.imageTransform ? { transform: guardian.imageTransform } : undefined}
+              style={(() => {
+                const s: React.CSSProperties = {};
+                if (guardian.imageScale && guardian.imageScale !== 1) {
+                  const sizePct = (1 / guardian.imageScale) * 100;
+                  const offset = (100 - sizePct) / 2;
+                  s.width = `${sizePct}%`;
+                  s.height = `${sizePct}%`;
+                  s.marginLeft = `${offset}%`;
+                  s.marginTop = `${offset}%`;
+                }
+                if (guardian.imageTransform) {
+                  s.transform = guardian.imageTransform;
+                }
+                return Object.keys(s).length > 0 ? s : undefined;
+              })()}
             />
           ) : (
             <div className="w-full h-full bg-[var(--color-background-muted)] flex items-center justify-center">

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -46,7 +46,8 @@ export const guardians: Guardian[] = [
     role: 'Guardian of Community & Programs',
     bio: 'With over a decade walking the Aura Reading path and a background in multiple traditions of self-knowledge, Dara integrates body, mind, and spirit with reverence. She supports the creation and delivery of programs and courses, blending intuitive listening with grounded clarity.',
     image: '/images/dara-new.png',
-    imageTransform: 'translateY(-8%)',
+    imageTransform: 'translateY(-10%)',
+    imageScale: 0.85,
   },
   {
     id: '4',

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -17,6 +17,8 @@ export interface Guardian {
   image: string;
   /** Optional CSS transform for fine-tuning photo position in circular crop */
   imageTransform?: string;
+  /** Optional scale factor (<1 zooms out to show more of the photo in the circular crop) */
+  imageScale?: number;
 }
 
 /** Program offering */


### PR DESCRIPTION
Add imageScale support to GuardianCard for zooming out within the
circular crop. Set Dara's imageScale to 0.85 so the photo appears
smaller in the frame, revealing head and shoulders.

https://claude.ai/code/session_01WykyL4d5oxFyXkvQobzQBf