### PR TITLE
Fix logo overlapping Community nav link on iPad

### DIFF
--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -157,13 +157,13 @@ export function Navigation({
         <nav className="container-premium">
           <div className="relative flex items-center h-16 lg:h-[72px] w-full">
             {/* Left: nav links — equal flex so logo stays centered */}
-            <div className="hidden lg:flex items-center gap-1 flex-1 min-w-0 justify-start">
+            <div className="hidden lg:flex items-center gap-1 flex-1 min-w-0 justify-start lg:pr-20">
               {items.map((item) => (
                 <Link
                   key={item.label}
                   href={item.href}
                   className={cn(
-                    'group relative px-4 py-2 text-sm font-medium rounded-lg',
+                    'group relative px-2 xl:px-4 py-2 text-sm font-medium rounded-lg',
                     'text-[var(--color-foreground-muted)]',
                     'hover:text-[var(--color-foreground)]',
                     'transition-colors duration-200'


### PR DESCRIPTION
Add right padding (pr-20) to the left nav container at the lg breakpoint
to reserve clear space for the absolutely-centered logo. Also reduce nav
link horizontal padding from px-4 to px-2 at lg (restored at xl) so all
five links fit without reaching into the logo zone.

https://claude.ai/code/session_012yQNLLAcQSTLDoi6fQsmPf