### PR TITLE
Adjust Dara bio image: shift left and zoom in slightly

### DIFF
--- a/src/components/sections/GuardianCard.tsx
+++ b/src/components/sections/GuardianCard.tsx
@@ -39,7 +39,10 @@ export default function GuardianCard({ guardian, className }: GuardianCardProps)
               fill
               sizes="(min-width: 768px) 160px, 128px"
               className="object-cover"
-              style={{ objectPosition: guardian.imagePosition ?? 'center 20%' }}
+              style={{
+                objectPosition: guardian.imagePosition ?? 'center 20%',
+                ...(guardian.imageScale ? { transform: `scale(${guardian.imageScale})` } : {}),
+              }}
             />
           ) : (
             <div className="w-full h-full bg-[var(--color-background-muted)] flex items-center justify-center">

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -47,7 +47,8 @@ export const guardians: Guardian[] = [
     role: 'Guardian of Community & Programs',
     bio: 'With over a decade walking the Aura Reading path and a background in multiple traditions of self-knowledge, Dara integrates body, mind, and spirit with reverence. She supports the creation and delivery of programs and courses, blending intuitive listening with grounded clarity.',
     image: '/images/BCE1985E-705D-46B4-9D52-E1B5A10C074E.png',
-    imagePosition: 'center 20%',
+    imagePosition: '55% 20%',
+    imageScale: 1.1,
   },
   {
     id: '4',

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -17,6 +17,8 @@ export interface Guardian {
   image: string;
   /** Optional CSS object-position value for fine-tuning which part of the photo is visible in the circular crop (e.g. "center 20%") */
   imagePosition?: string;
+  /** Optional scale factor for zooming into the photo (e.g. 1.1 for 10% zoom) */
+  imageScale?: number;
 }
 
 /** Program offering */


### PR DESCRIPTION
Move object-position from center to 55% horizontal to better center
Dara in the circular crop, and add 1.1x scale for a slight zoom.
Adds imageScale property to Guardian type for per-guardian zoom control.

https://claude.ai/code/session_018kvPYwH7T4fevWG6NtPTgu