### PR TITLE
Add small rose logo above heading on main page

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -582,6 +582,22 @@ export default function Home() {
             A Consciousness &amp; Remembrance Ecosystem
           </motion.p>
 
+          <motion.div
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={ready ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0.8 }}
+            transition={{ delay: 0.15, duration: 0.6 }}
+            className="mb-5 lg:mb-6"
+          >
+            <Image
+              src="/rose.png"
+              alt="ROSES OS"
+              width={48}
+              height={48}
+              className="object-contain"
+              priority
+            />
+          </motion.div>
+
           <h1
             ref={titleRef}
             className="font-serif text-[clamp(2rem,5.5vw,4.5rem)] leading-[1.05] tracking-tighter text-balance max-w-5xl"


### PR DESCRIPTION
Adds an animated rose.png logo image above the "A Seamless Path to Inner Freedom"
heading in the hero section. The logo fades in with a subtle scale animation
that plays before the title words animate in.

https://claude.ai/code/session_0178DBEge6SrrYZJf7NpYnG3