### PR TITLE
Hide The Codex from public UI while preserving all code and data

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,16 @@ const nextConfig: NextConfig = {
     // Pre-existing type error in admin/page.tsx (framer-motion Variants typing)
     ignoreBuildErrors: true,
   },
+  // Hidden pages — remove redirect when ready to make public again
+  async redirects() {
+    return [
+      {
+        source: '/the-codex',
+        destination: '/',
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -13,7 +13,7 @@ const navLinks = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  { label: 'The Codex', href: '/the-codex' },
+  // { label: 'The Codex', href: '/the-codex' }, // Hidden — re-enable when ready
   { label: 'Community', href: '/community' },
   { label: 'Contact', href: '/contact' },
 ];

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -29,7 +29,7 @@ const defaultItems: NavItem[] = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  { label: 'The Codex', href: '/the-codex' },
+  // { label: 'The Codex', href: '/the-codex' }, // Hidden — re-enable when ready
   { label: 'Community', href: '/community' },
 ];
 

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -17,7 +17,7 @@ export const navItems: NavItem[] = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  { label: 'The Codex', href: '/the-codex' },
+  // { label: 'The Codex', href: '/the-codex' }, // Hidden — re-enable when ready
   { label: 'Community', href: '/community' },
 ];
 


### PR DESCRIPTION
Removes The Codex from header nav, footer nav, and mock data nav items.
Adds a temporary redirect from /the-codex to / so direct URL access is
blocked. All page code, components, and data remain intact — uncomment
the nav entries and remove the redirect when ready to make it public.

https://claude.ai/code/session_016TdHWbdzWbA2h62nyzpMrt