### PR TITLE
Make The Codex page publicly accessible

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,16 +5,6 @@ const nextConfig: NextConfig = {
     // Pre-existing type error in admin/page.tsx (framer-motion Variants typing)
     ignoreBuildErrors: true,
   },
-  // Hidden pages — remove redirect when ready to make public again
-  async redirects() {
-    return [
-      {
-        source: '/the-codex',
-        destination: '/',
-        permanent: false,
-      },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -13,7 +13,7 @@ const navLinks = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  // { label: 'The Codex', href: '/the-codex' }, // Hidden — re-enable when ready
+  { label: 'The Codex', href: '/the-codex' },
   { label: 'Community', href: '/community' },
   { label: 'Contact', href: '/contact' },
 ];

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -29,7 +29,7 @@ const defaultItems: NavItem[] = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  // { label: 'The Codex', href: '/the-codex' }, // Hidden — re-enable when ready
+  { label: 'The Codex', href: '/the-codex' },
   { label: 'Community', href: '/community' },
 ];
 

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -17,7 +17,7 @@ export const navItems: NavItem[] = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  // { label: 'The Codex', href: '/the-codex' }, // Hidden — re-enable when ready
+  { label: 'The Codex', href: '/the-codex' },
   { label: 'Community', href: '/community' },
 ];
 


### PR DESCRIPTION
Reverses the hiding of The Codex by removing the /the-codex → / redirect
and re-enabling navigation links in the header, footer, and mock data.

https://claude.ai/code/session_01XFCNurw8AZngH6w85p1V32