### PR TITLE
Hide The Codex from site navigation while preserving all content

### DIFF
--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -13,7 +13,6 @@ const navLinks = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  { label: 'The Codex', href: '/the-codex' },
   { label: 'Community', href: '/community' },
   { label: 'Contact', href: '/contact' },
 ];

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -29,7 +29,6 @@ const defaultItems: NavItem[] = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  { label: 'The Codex', href: '/the-codex' },
   { label: 'Community', href: '/community' },
 ];
 

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -18,7 +18,6 @@ export const navItems: NavItem[] = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Programs', href: '/programs' },
   { label: 'Guardians', href: '/guardians' },
-  { label: 'The Codex', href: '/the-codex' },
   { label: 'Community', href: '/community' },
 ];
 


### PR DESCRIPTION
Remove The Codex link from the main navigation, footer, and shared
nav data. The page, components, data, and documentation all remain
intact for future re-enabling.

https://claude.ai/code/session_011cAafRxFoYyVywxpNFyZEB