### PR TITLE
Update contribution section to clarify Foundational and Full Program offerings

### DIFF
--- a/src/components/forms/ContributionForm.tsx
+++ b/src/components/forms/ContributionForm.tsx
@@ -111,11 +111,13 @@ export function ContributionForm({ tiers, onSubmit, className }: ContributionFor
                 {/* Pricing */}
                 <div className="mt-3 space-y-1 w-full text-left">
                   <p className="text-sm text-[var(--color-foreground-muted)]">
-                    <span className="font-medium text-[var(--color-foreground)]">Foundational:</span>{' '}
+                    <span className="font-medium text-[var(--color-foreground)]">Foundational</span>{' '}
+                    <span className="text-xs text-[var(--color-foreground-faint)]">(Rose 1, 2 &amp; 3)</span>{' '}
                     {tier.priceFoundational}
                   </p>
                   <p className="text-sm text-[var(--color-foreground-muted)]">
-                    <span className="font-medium text-[var(--color-foreground)]">Full Program:</span>{' '}
+                    <span className="font-medium text-[var(--color-foreground)]">Full Program</span>{' '}
+                    <span className="text-xs text-[var(--color-foreground-faint)]">(Rose &amp; Aura 1)</span>{' '}
                     {tier.priceFull}
                   </p>
                 </div>

--- a/src/components/sections/ContributionTiers.tsx
+++ b/src/components/sections/ContributionTiers.tsx
@@ -86,11 +86,13 @@ export default function ContributionTiers({
               {/* Pricing */}
               <div className="mb-3 space-y-1">
                 <p className="text-sm text-[var(--color-foreground-muted)]">
-                  <span className="font-medium text-[var(--color-foreground)]">Foundational:</span>{' '}
+                  <span className="font-medium text-[var(--color-foreground)]">Foundational</span>{' '}
+                  <span className="text-xs text-[var(--color-foreground-faint)]">(Rose 1, 2 &amp; 3)</span>{' '}
                   {tier.priceFoundational}
                 </p>
                 <p className="text-sm text-[var(--color-foreground-muted)]">
-                  <span className="font-medium text-[var(--color-foreground)]">Full Program:</span>{' '}
+                  <span className="font-medium text-[var(--color-foreground)]">Full Program</span>{' '}
+                  <span className="text-xs text-[var(--color-foreground-faint)]">(Rose &amp; Aura 1)</span>{' '}
                   {tier.priceFull}
                 </p>
               </div>

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -39,9 +39,9 @@ export interface ContributionTier {
   name: string;
   range: string;
   description: string;
-  /** Suggested price for Foundational only (Rose Meditation Weekend 1) */
+  /** Suggested price for Foundational (Rose Meditation Levels 1, 2 & 3) */
   priceFoundational: string;
-  /** Suggested price for the Full Program */
+  /** Suggested price for the Full Program (Rose & Aura Reading Level 1) */
   priceFull: string;
 }
 


### PR DESCRIPTION
Foundational now shows "(Rose 1, 2 & 3)" and Full Program shows
"(Rose & Aura 1)" so users understand exactly which levels each
pricing tier covers. Also corrects the type comment that previously
referenced "Rose Meditation Weekend 1".

https://claude.ai/code/session_01XZmtoGYzP26dAQwhpELz9Q