### PR TITLE
Consolidate duplicate content across site pages

### DIFF
--- a/src/app/(invitation)/invitation/learn-more/page.tsx
+++ b/src/app/(invitation)/invitation/learn-more/page.tsx
@@ -4,19 +4,10 @@ import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import {
-  programs,
-  scheduleStages,
-  contributionTiers,
-  agreements,
-} from '@/lib/data';
 
 import { Navigation } from '@/components/ui/Navigation';
 import Footer from '@/components/ui/Footer';
 import PageHero from '@/components/sections/PageHero';
-import ProgramCard from '@/components/sections/ProgramCard';
-import ScheduleTable from '@/components/sections/ScheduleTable';
-import ContributionTiers from '@/components/sections/ContributionTiers';
 
 // =============================================================================
 // SHARED EASE
@@ -25,130 +16,106 @@ import ContributionTiers from '@/components/sections/ContributionTiers';
 const ease = [0.16, 1, 0.3, 1] as const;
 
 // =============================================================================
-// SECTION: Programs Detail
+// SECTION: Overview
 // =============================================================================
 
-function ProgramsDetail() {
+function OverviewSection() {
   const ref = useRef<HTMLElement>(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
   return (
     <section ref={ref} className="section-padding">
-      <div className="container-premium">
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, ease }}
-          className="label-sacred mb-4"
-        >
-          Programs
-        </motion.p>
+      <div className="container-premium max-w-3xl mx-auto">
         <motion.h2
           initial={{ opacity: 0, y: 24 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.1, ease }}
-          className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-10"
+          className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-6"
         >
-          What we offer
+          How It Works
         </motion.h2>
-        <div className="grid md:grid-cols-2 gap-6 max-w-5xl">
-          {programs.map((program) => (
-            <ProgramCard key={program.id} program={program} />
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-// =============================================================================
-// SECTION: Schedule
-// =============================================================================
-
-function ScheduleSection() {
-  const ref = useRef<HTMLElement>(null);
-  const isInView = useInView(ref, { once: true, margin: '-100px' });
-
-  return (
-    <section ref={ref} className="section-padding bg-[var(--color-background-subtle)]">
-      <div className="container-premium">
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, ease }}
-          className="label-sacred mb-4"
-        >
-          Schedule
-        </motion.p>
-        <motion.h2
-          initial={{ opacity: 0, y: 24 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, delay: 0.1, ease }}
-          className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-10"
-        >
-          Program timeline
-        </motion.h2>
-        <div className="max-w-4xl">
-          <ScheduleTable stages={scheduleStages} />
-        </div>
-      </div>
-    </section>
-  );
-}
-
-// =============================================================================
-// SECTION: Contribution Model
-// =============================================================================
-
-function ContributionSection() {
-  const ref = useRef<HTMLElement>(null);
-  const isInView = useInView(ref, { once: true, margin: '-100px' });
-
-  return (
-    <section ref={ref} className="section-padding">
-      <div className="container-premium">
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, ease }}
-          className="label-sacred mb-4"
-        >
-          Contribution Model
-        </motion.p>
-        <motion.h2
-          initial={{ opacity: 0, y: 24 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, delay: 0.1, ease }}
-          className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-4"
-        >
-          Income-based pricing
-        </motion.h2>
-        <motion.p
+        <motion.div
           initial={{ opacity: 0, y: 24 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.2, ease }}
-          className="text-base text-[var(--color-foreground-muted)] leading-relaxed max-w-2xl mb-10"
+          className="text-lg text-[var(--color-foreground-muted)] leading-relaxed space-y-6"
         >
-          We believe that access to this work should not be limited by financial
-          circumstance. Our contribution model is based on trust and
-          self-assessment. Choose the tier that reflects your current season of
-          life.
-        </motion.p>
-        <div className="max-w-4xl">
-          <ContributionTiers tiers={contributionTiers} />
-        </div>
+          <p>
+            ROSES OS offers guided programs in Rose Meditation and Aura Reading.
+            Each program is held live, online, and designed to meet you exactly
+            where you are. No prior experience is needed.
+          </p>
+          <p>
+            We use an income-based contribution model so that financial
+            circumstances never stand between you and this work. You choose the
+            tier that reflects your current season of life.
+          </p>
+          <p>
+            Before enrolling, you will be asked to accept five sacred agreements
+            that hold the integrity of our container: Commitment to Practice,
+            Confidentiality, Respect for the Lineage, Personal Responsibility,
+            and Community Care.
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={isInView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6, delay: 0.3, ease }}
+          className="mt-10"
+        >
+          <Link
+            href="/programs"
+            className={cn(
+              'inline-flex items-center gap-2',
+              'text-sm font-medium',
+              'text-[var(--color-foreground)]',
+              'underline underline-offset-4 decoration-[var(--color-rose-clay)]',
+              'hover:text-[var(--color-foreground-muted)]',
+              'transition-colors duration-200'
+            )}
+          >
+            View programs, schedule & contribution details
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+            </svg>
+          </Link>
+        </motion.div>
       </div>
     </section>
   );
 }
 
 // =============================================================================
-// SECTION: Agreements
+// SECTION: What to Expect
 // =============================================================================
 
-function AgreementsSection() {
+function WhatToExpect() {
   const ref = useRef<HTMLElement>(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
+
+  const steps = [
+    {
+      number: '01',
+      title: 'Explore',
+      description: 'Read about the programs and find the offering that resonates with where you are.',
+    },
+    {
+      number: '02',
+      title: 'Enroll',
+      description: 'Complete a brief enrollment form and select your contribution tier.',
+    },
+    {
+      number: '03',
+      title: 'Prepare',
+      description: 'Accept the five sacred agreements and receive your welcome materials.',
+    },
+    {
+      number: '04',
+      title: 'Begin',
+      description: 'Join live sessions with the guardians and fellow practitioners.',
+    },
+  ];
 
   return (
     <section ref={ref} className="section-padding bg-[var(--color-background-subtle)]">
@@ -157,51 +124,40 @@ function AgreementsSection() {
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, ease }}
-          className="label-sacred mb-4"
+          className="label-sacred mb-4 text-center"
         >
-          Our Agreements
+          Your Journey
         </motion.p>
         <motion.h2
           initial={{ opacity: 0, y: 24 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.1, ease }}
-          className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-10"
+          className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-12 text-center"
         >
-          Five sacred agreements
+          What to expect
         </motion.h2>
-        <div className="max-w-3xl space-y-6">
-          {agreements.map((agreement, i) => (
+        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6 max-w-5xl mx-auto">
+          {steps.map((step, i) => (
             <motion.div
-              key={agreement.id}
+              key={step.number}
               initial={{ opacity: 0, y: 24 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.5, delay: 0.15 + i * 0.08, ease }}
+              transition={{ duration: 0.6, delay: 0.15 + i * 0.1, ease }}
               className={cn(
-                'flex gap-5',
-                'py-5',
-                'border-b border-[var(--color-border-subtle)]',
-                'last:border-b-0'
+                'rounded-xl p-6',
+                'bg-[var(--color-background-elevated)]',
+                'border border-[var(--color-border-subtle)]'
               )}
             >
-              <span
-                className={cn(
-                  'flex-shrink-0 flex items-center justify-center',
-                  'w-8 h-8 rounded-full',
-                  'bg-[#9E956B]/10 text-[#9E956B]',
-                  'font-serif font-semibold text-sm',
-                  'border border-[#9E956B]/20'
-                )}
-              >
-                {i + 1}
+              <span className="block font-serif text-2xl text-[#9E956B]/50 mb-3">
+                {step.number}
               </span>
-              <div className="flex-1 min-w-0">
-                <h3 className="font-serif font-semibold text-base text-[var(--color-foreground)] leading-snug mb-1">
-                  {agreement.title}
-                </h3>
-                <p className="text-sm text-[var(--color-foreground-muted)] leading-relaxed">
-                  {agreement.description}
-                </p>
-              </div>
+              <h3 className="font-serif font-semibold text-base text-[var(--color-foreground)] mb-2">
+                {step.title}
+              </h3>
+              <p className="text-sm text-[var(--color-foreground-muted)] leading-relaxed">
+                {step.description}
+              </p>
             </motion.div>
           ))}
         </div>
@@ -235,6 +191,7 @@ function ReadyCTA() {
             initial={{ opacity: 0, y: 24 }}
             animate={isInView ? { opacity: 1, y: 0 } : {}}
             transition={{ duration: 0.6, delay: 0.2, ease }}
+            className="flex flex-col sm:flex-row items-center justify-center gap-4"
           >
             <Link
               href="/enroll"
@@ -247,6 +204,18 @@ function ReadyCTA() {
               )}
             >
               Enroll Now
+            </Link>
+            <Link
+              href="/programs"
+              className={cn(
+                'px-8 py-3.5 rounded-full',
+                'border-2 border-white/30 text-white',
+                'text-sm font-medium',
+                'hover:border-white/60 hover:bg-white/5',
+                'transition-all duration-200'
+              )}
+            >
+              View Programs
             </Link>
           </motion.div>
         </div>
@@ -268,25 +237,19 @@ export default function LearnMorePage() {
         {/* 1. Hero */}
         <PageHero
           title="Everything You Need to Know"
-          description="A detailed look at the ROSES OS programs, schedule, contribution model, and the sacred agreements that hold our container. Take your time. Read what calls to you."
+          description="A clear overview of how ROSES OS works, what to expect, and how to get started."
         />
 
-        {/* 2. Detailed program information */}
-        <ProgramsDetail />
+        {/* 2. How it works overview */}
+        <OverviewSection />
 
-        {/* 3. Schedule overview */}
-        <ScheduleSection />
+        {/* 3. What to expect steps */}
+        <WhatToExpect />
 
-        {/* 4. Contribution model */}
-        <ContributionSection />
-
-        {/* 5. Agreements preview */}
-        <AgreementsSection />
-
-        {/* 6. CTA */}
+        {/* 4. CTA */}
         <ReadyCTA />
 
-        {/* 7. Back link */}
+        {/* 5. Back link */}
         <section className="py-10">
           <div className="container-premium">
             <Link

--- a/src/app/(invitation)/invitation/page.tsx
+++ b/src/app/(invitation)/invitation/page.tsx
@@ -4,9 +4,8 @@ import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { messagingPillars, guardians, programs } from '@/lib/data';
+import { programs } from '@/lib/data';
 
-import GuardianCard from '@/components/sections/GuardianCard';
 import ProgramCard from '@/components/sections/ProgramCard';
 
 // =============================================================================
@@ -48,9 +47,9 @@ function InvitationHero() {
           transition={{ delay: 0.5, duration: 0.8, ease }}
           className="font-serif text-[clamp(2.5rem,6vw,5rem)] leading-[1.05] tracking-tighter text-balance max-w-4xl mx-auto"
         >
-          A Seamless Path to
+          You Have Been
           <br />
-          Inner Freedom
+          Invited
         </motion.h1>
 
         <motion.p
@@ -59,7 +58,7 @@ function InvitationHero() {
           transition={{ delay: 0.9, duration: 0.6, ease }}
           className="mt-6 text-lg sm:text-xl text-warm-300 max-w-xl mx-auto leading-relaxed"
         >
-          Technologies of remembrance for those ready to live in coherence.
+          A personal doorway into the Rose field. Everything you need to begin is here.
         </motion.p>
 
         <motion.div
@@ -143,63 +142,21 @@ function WhatIsRosesOS() {
 }
 
 // =============================================================================
-// SECTION: Three Pillars
+// SECTION: Guardians Link
 // =============================================================================
 
-function ThreePillars() {
+function GuardiansLink() {
   const ref = useRef<HTMLElement>(null);
   const isInView = useInView(ref, { once: true, margin: '-100px' });
 
   return (
-    <section ref={ref} className="section-padding bg-[var(--color-section-dark)] text-white">
-      <div className="container-premium">
+    <section ref={ref} className="section-padding bg-[var(--color-background-subtle)]">
+      <div className="container-premium max-w-3xl mx-auto text-center">
         <motion.p
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, ease }}
-          className="text-[11px] font-medium uppercase tracking-[0.2em] text-warm-400 text-center mb-12"
-        >
-          Three Pillars
-        </motion.p>
-        <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
-          {messagingPillars.map((pillar, i) => (
-            <motion.div
-              key={pillar.id}
-              initial={{ opacity: 0, y: 24 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.6, delay: 0.1 + i * 0.15, ease }}
-              className="text-center"
-            >
-              <h3 className="font-serif text-2xl tracking-tight mb-4 text-white">
-                {pillar.title}
-              </h3>
-              <p className="text-warm-300 leading-relaxed">
-                {pillar.description}
-              </p>
-            </motion.div>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
-// =============================================================================
-// SECTION: Guardians
-// =============================================================================
-
-function GuardiansSection() {
-  const ref = useRef<HTMLElement>(null);
-  const isInView = useInView(ref, { once: true, margin: '-100px' });
-
-  return (
-    <section ref={ref} className="section-padding">
-      <div className="container-premium">
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, ease }}
-          className="label-sacred text-center mb-4"
+          className="label-sacred mb-4"
         >
           The Guardians
         </motion.p>
@@ -207,15 +164,41 @@ function GuardiansSection() {
           initial={{ opacity: 0, y: 24 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.1, ease }}
-          className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight text-center mb-12"
+          className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-6"
         >
-          Your guides on the path
+          Held by those who walk the path
         </motion.h2>
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-8 max-w-5xl mx-auto">
-          {guardians.map((guardian) => (
-            <GuardianCard key={guardian.id} guardian={guardian} />
-          ))}
-        </div>
+        <motion.p
+          initial={{ opacity: 0, y: 24 }}
+          animate={isInView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6, delay: 0.2, ease }}
+          className="text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8"
+        >
+          Four guardians steward the Rose field — each bringing decades of
+          practice, devotion, and lived experience to support your journey.
+        </motion.p>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={isInView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6, delay: 0.3, ease }}
+        >
+          <Link
+            href="/guardians"
+            className={cn(
+              'inline-flex items-center gap-2',
+              'text-sm font-medium',
+              'text-[var(--color-foreground)]',
+              'underline underline-offset-4 decoration-[var(--color-rose-clay)]',
+              'hover:text-[var(--color-foreground-muted)]',
+              'transition-colors duration-200'
+            )}
+          >
+            Meet the Guardians
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+            </svg>
+          </Link>
+        </motion.div>
       </div>
     </section>
   );
@@ -428,9 +411,8 @@ export default function InvitationPage() {
     <>
       <InvitationHero />
       <WhatIsRosesOS />
-      <ThreePillars />
-      <GuardiansSection />
       <WhatAwakensSection />
+      <GuardiansLink />
       <ProgramsSection />
       <FinalCTA />
     </>

--- a/src/app/(site)/community/page.tsx
+++ b/src/app/(site)/community/page.tsx
@@ -4,7 +4,6 @@ import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { architectureLayers } from '@/lib/data';
 
 import PageHero from '@/components/sections/PageHero';
 import InvitationCTA from '@/components/sections/InvitationCTA';
@@ -16,9 +15,6 @@ import InvitationCTA from '@/components/sections/InvitationCTA';
 export default function CommunityPage() {
   const visionRef = useRef<HTMLElement>(null);
   const visionInView = useInView(visionRef, { once: true, margin: '-100px' });
-
-  const archRef = useRef<HTMLElement>(null);
-  const archInView = useInView(archRef, { once: true, margin: '-100px' });
 
   const participateRef = useRef<HTMLElement>(null);
   const participateInView = useInView(participateRef, { once: true, margin: '-100px' });
@@ -75,69 +71,57 @@ export default function CommunityPage() {
         </div>
       </section>
 
-      {/* 3. Architecture Layers */}
-      <section
-        ref={archRef}
-        className="section-padding bg-[var(--color-background-subtle)]"
-      >
-        <div className="container-premium">
+      {/* 3. The Architecture — brief reference with link to The Codex */}
+      <section className="section-padding bg-[var(--color-background-subtle)]">
+        <div className="container-premium max-w-3xl mx-auto text-center">
           <motion.p
             initial={{ opacity: 0, y: 20 }}
-            animate={archInView ? { opacity: 1, y: 0 } : {}}
+            animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
-            className="label-sacred mb-4 text-center"
+            className="label-sacred mb-6"
           >
             The Architecture
           </motion.p>
           <motion.h2
             initial={{ opacity: 0, y: 24 }}
-            animate={archInView ? { opacity: 1, y: 0 } : {}}
+            animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.1, ease: [0.16, 1, 0.3, 1] }}
-            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-10 text-center"
+            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-6"
           >
-            Four Layers of the Living System
+            Built on Four Living Layers
           </motion.h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {architectureLayers.map((layer, i) => (
-              <motion.div
-                key={layer.id}
-                initial={{ opacity: 0, y: 24 }}
-                animate={archInView ? { opacity: 1, y: 0 } : {}}
-                transition={{
-                  duration: 0.6,
-                  delay: 0.15 + i * 0.1,
-                  ease: [0.16, 1, 0.3, 1],
-                }}
-                className={cn(
-                  'rounded-2xl p-6 md:p-8',
-                  'bg-[var(--color-background-elevated)]',
-                  'border border-[var(--color-border)]',
-                  'transition-shadow duration-300',
-                  'hover:shadow-[var(--shadow-md)]'
-                )}
-              >
-                <div className="flex items-center gap-3 mb-4">
-                  <span
-                    className={cn(
-                      'flex items-center justify-center',
-                      'w-8 h-8 rounded-full',
-                      'bg-[#9E956B]/10 text-[#9E956B]',
-                      'font-serif font-semibold text-sm',
-                      'border border-[#9E956B]/20'
-                    )}
-                  >
-                    {i + 1}
-                  </span>
-                </div>
-                <h3 className="font-serif text-xl tracking-tight text-[var(--color-foreground)] mb-3">
-                  {layer.name}
-                </h3>
-                <p className="text-sm text-[var(--color-foreground-muted)] leading-relaxed">
-                  {layer.description}
-                </p>
-              </motion.div>
-            ))}
-          </div>
+          <motion.p
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2, ease: [0.16, 1, 0.3, 1] }}
+            className="text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8"
+          >
+            The community rests on a four-layer architecture — Hardware, Software,
+            Heartware, and Soulware — each sustaining a different dimension of
+            coherent living.
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.3, ease: [0.16, 1, 0.3, 1] }}
+          >
+            <Link
+              href="/the-codex"
+              className={cn(
+                'inline-flex items-center gap-2',
+                'text-sm font-medium',
+                'text-[var(--color-foreground)]',
+                'underline underline-offset-4 decoration-[var(--color-rose-clay)]',
+                'hover:text-[var(--color-foreground-muted)]',
+                'transition-colors duration-200'
+              )}
+            >
+              Explore the full architecture in The Codex
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+              </svg>
+            </Link>
+          </motion.div>
         </div>
       </section>
 

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -438,19 +438,11 @@ function InvitationCTA() {
             <br />
             <span className="text-rose-400">Welcome home.</span>
           </motion.h2>
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={isInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6, delay: 0.15 }}
-            className="mt-6 text-white/50 text-lg max-w-md mx-auto"
-          >
-            Begin the journey back to yourself.
-          </motion.p>
           <motion.div
             initial={{ opacity: 0, y: 24 }}
             animate={isInView ? { opacity: 1, y: 0 } : {}}
             transition={{ duration: 0.6, delay: 0.3, ease: [0.16, 1, 0.3, 1] }}
-            className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"
+            className="mt-10"
           >
             <Link
               href="/invitation"
@@ -464,7 +456,7 @@ function InvitationCTA() {
                 'inline-flex items-center gap-2'
               )}
             >
-              Begin Your Journey
+              Enter the Rose Field
               <svg
                 className="w-4 h-4 transition-transform duration-200 group-hover:translate-x-0.5"
                 fill="none"
@@ -474,19 +466,6 @@ function InvitationCTA() {
               >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" />
               </svg>
-            </Link>
-            <Link
-              href="/the-rose"
-              className={cn(
-                'px-8 py-3.5 rounded-full',
-                'text-sm font-medium',
-                'text-white/80',
-                'border border-white/20',
-                'hover:bg-white/10 hover:border-white/30',
-                'transition-all duration-300'
-              )}
-            >
-              Explore The Rose
             </Link>
           </motion.div>
         </div>

--- a/src/app/(site)/the-codex/page.tsx
+++ b/src/app/(site)/the-codex/page.tsx
@@ -3,10 +3,10 @@
 import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { cn } from '@/lib/utils';
+import Link from 'next/link';
 import {
   lineageEntries,
   coherenceDomains,
-  visiblePathLevels,
   architectureLayers,
   elevenCapacities,
 } from '@/lib/data';
@@ -16,7 +16,6 @@ import QuoteBlock from '@/components/sections/QuoteBlock';
 import InvitationCTA from '@/components/sections/InvitationCTA';
 import LineageTimeline from '@/components/sections/LineageTimeline';
 import DomainGrid from '@/components/sections/DomainGrid';
-import PathLevels from '@/components/sections/PathLevels';
 import ElevenCapacities from '@/components/sections/ElevenCapacities';
 
 // =============================================================================
@@ -210,9 +209,60 @@ export default function TheCodexPage() {
       <SectionLabel>13 Domains of Coherence</SectionLabel>
       <DomainGrid domains={coherenceDomains} />
 
-      {/* 6. The Path */}
-      <SectionLabel>The Path</SectionLabel>
-      <PathLevels levels={visiblePathLevels} variant="full" />
+      {/* 6. The Path — brief overview with link to /the-rose for full details */}
+      <section className="section-padding">
+        <div className="container-premium max-w-3xl mx-auto">
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, ease }}
+            className="label-sacred mb-6"
+          >
+            The Path
+          </motion.p>
+          <motion.h2
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1, ease }}
+            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-6"
+          >
+            Eight Levels of Remembrance
+          </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2, ease }}
+            className="text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8"
+          >
+            The path unfolds across eight levels — three Rose Meditations and five
+            Aura Readings — each deepening your relationship with inner coherence.
+            From grounding and aura awareness through to spiritual activation and
+            advanced perception, every level builds on the last.
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.3, ease }}
+          >
+            <Link
+              href="/the-rose"
+              className={cn(
+                'inline-flex items-center gap-2',
+                'text-sm font-medium',
+                'text-[var(--color-foreground)]',
+                'underline underline-offset-4 decoration-[var(--color-rose-clay)]',
+                'hover:text-[var(--color-foreground-muted)]',
+                'transition-colors duration-200'
+              )}
+            >
+              Explore all levels on The Rose
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+              </svg>
+            </Link>
+          </motion.div>
+        </div>
+      </section>
 
       {/* 7. Four Layers of the Architecture */}
       <ArchitectureLayers />

--- a/src/app/(site)/the-rose/page.tsx
+++ b/src/app/(site)/the-rose/page.tsx
@@ -4,7 +4,7 @@ import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { visiblePathLevels, brandQuotes } from '@/lib/data';
+import { visiblePathLevels } from '@/lib/data';
 
 import PageHero from '@/components/sections/PageHero';
 import PathLevels from '@/components/sections/PathLevels';
@@ -157,7 +157,7 @@ export default function TheRosePage() {
 
       {/* 7. Quote */}
       <QuoteBlock
-        quote="What if the intelligence you seek is already within you, waiting to be remembered?"
+        quote="The body already knows. The heart already knows. The practice is simply learning to listen."
         variant="fullbleed"
       />
 


### PR DESCRIPTION
Remove repeated content blocks that appeared verbatim on multiple pages,
replacing them with concise summaries and cross-links to canonical locations:

- /the-codex: Replace full PathLevels grid with brief overview + link to /the-rose
- /community: Replace full architecture layers grid with summary + link to /the-codex
- /invitation: Remove duplicate Three Pillars and Guardians sections; replace
  guardians with brief link-out to /guardians page; give hero unique messaging
  instead of duplicating home hero headline
- /invitation/learn-more: Remove duplicate programs, schedule, contribution tiers,
  and agreements (all duplicated from /programs); replace with concise How It Works
  overview and What to Expect steps with links to /programs
- Home: Differentiate bottom CTA from hero CTA (single Enter the Rose Field
  button instead of duplicating hero two-button layout)
- /the-rose: Replace duplicate brand quote with unique quote

https://claude.ai/code/session_01DXhGjXxVfNta4Pra25QnRV