### PR TITLE
Remove redundant description from Learn More page hero

### DIFF
--- a/src/app/(invitation)/invitation/learn-more/page.tsx
+++ b/src/app/(invitation)/invitation/learn-more/page.tsx
@@ -237,7 +237,6 @@ export default function LearnMorePage() {
         {/* 1. Hero */}
         <PageHero
           title="Everything You Need to Know"
-          description="A clear overview of how ROSES OS works, what to expect, and how to get started."
         />
 
         {/* 2. How it works overview */}


### PR DESCRIPTION
The description line was redundant with the page title and content.

https://claude.ai/code/session_01PZ83Boor5RZmaQA3Gc6ajP