### PR TITLE
Replace em dashes with commas, colons, or hyphens across all site pages

### DIFF
--- a/src/app/(invitation)/invitation/page.tsx
+++ b/src/app/(invitation)/invitation/page.tsx
@@ -174,7 +174,7 @@ function GuardiansLink() {
           transition={{ duration: 0.6, delay: 0.2, ease }}
           className="text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8"
         >
-          Four guardians steward the Rose field — each bringing decades of
+          Four guardians steward the Rose field, each bringing decades of
           practice, devotion, and lived experience to support your journey.
         </motion.p>
         <motion.div
@@ -217,12 +217,12 @@ const awakenings = [
   {
     title: 'Aura',
     description:
-      'When heart aligns with soul, you perceive subtle senses and the energy shaping your choices. Each reading is a mirror — strengthening clarity, relationships, and service.',
+      'When heart aligns with soul, you perceive subtle senses and the energy shaping your choices. Each reading is a mirror, strengthening clarity, relationships, and service.',
   },
   {
     title: 'Human Journey',
     description:
-      'Emotional patterns and imprints dissolve — freed across mental and energetic layers. Love reveals itself as a self-organizing intelligence.',
+      'Emotional patterns and imprints dissolve, freed across mental and energetic layers. Love reveals itself as a self-organizing intelligence.',
   },
   {
     title: 'Intuition',

--- a/src/app/(site)/community/page.tsx
+++ b/src/app/(site)/community/page.tsx
@@ -96,8 +96,8 @@ export default function CommunityPage() {
             transition={{ duration: 0.6, delay: 0.2, ease: [0.16, 1, 0.3, 1] }}
             className="text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8"
           >
-            The community rests on a four-layer architecture — Hardware, Software,
-            Heartware, and Soulware — each sustaining a different dimension of
+            The community rests on a four-layer architecture: Hardware, Software,
+            Heartware, and Soulware, each sustaining a different dimension of
             coherent living.
           </motion.p>
           <motion.div

--- a/src/app/(site)/offerings/page.tsx
+++ b/src/app/(site)/offerings/page.tsx
@@ -228,7 +228,7 @@ export default function OfferingsPage() {
               className="text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8"
             >
               The first level is now open. Eleven days combining Rose Meditation
-              1, 2 & 3 with Aura Reading Level 1 — a complete foundation for
+              1, 2 & 3 with Aura Reading Level 1: a complete foundation for
               the journey ahead.
             </motion.p>
             <motion.div

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -162,7 +162,7 @@ function BrandEssence() {
           className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto"
         >
           ROSES OS is a living consciousness ecosystem of practices, teachings,
-          and community — designed to help you remember what you already know and
+          and community, designed to help you remember what you already know and
           live from that place. Not a course. Not a cure. A way home.
         </motion.p>
 

--- a/src/app/(site)/the-codex/page.tsx
+++ b/src/app/(site)/the-codex/page.tsx
@@ -234,8 +234,8 @@ export default function TheCodexPage() {
             transition={{ duration: 0.6, delay: 0.2, ease }}
             className="text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8"
           >
-            The path unfolds across eight levels — three Rose Meditations and five
-            Aura Readings — each deepening your relationship with inner coherence.
+            The path unfolds across eight levels: three Rose Meditations and five
+            Aura Readings, each deepening your relationship with inner coherence.
             From grounding and aura awareness through to spiritual activation and
             advanced perception, every level builds on the last.
           </motion.p>

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -127,7 +127,7 @@ export const scheduleStages: ScheduleStage[] = [
     sessions: [
       { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '8:00 – 8:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
       { day: 'Class (mandatory)', duration: '3 hours', time: { sanJose: '8:00 – 11:00 AM', bogota: '9:00 AM – 12:00 PM', newYork: '10:00 AM – 1:00 PM', brasilia: '11:00 AM – 2:00 PM', london: '2:00 – 5:00 PM', madrid: '3:00 – 6:00 PM' } },
-      { day: 'Practice 1: Europe', duration: '1.5 hours', time: { sanJose: '—', bogota: '—', newYork: '—', brasilia: '7:00 – 8:30 AM', london: '10:00 – 11:30 AM', madrid: '11:00 AM – 12:30 PM' } },
+      { day: 'Practice 1: Europe', duration: '1.5 hours', time: { sanJose: '-', bogota: '-', newYork: '-', brasilia: '7:00 – 8:30 AM', london: '10:00 – 11:30 AM', madrid: '11:00 AM – 12:30 PM' } },
       { day: 'Practice 2', duration: '1.5 hours', time: { sanJose: '12:00 – 1:30 PM', bogota: '1:00 – 2:30 PM', newYork: '2:00 – 3:30 PM', brasilia: '3:00 – 4:30 PM', london: '6:00 – 7:30 PM', madrid: '7:00 – 8:30 PM' } },
       { day: 'Practice 3', duration: '1.5 hours', time: { sanJose: '2:30 – 4:00 PM', bogota: '3:30 – 5:00 PM', newYork: '4:30 – 6:00 PM', brasilia: '5:30 – 7:00 PM', london: '8:30 – 10:00 PM', madrid: '9:30 – 11:00 PM' } },
     ],


### PR DESCRIPTION
Removed all user-visible em dashes from site copy, preferring
lighter punctuation: commas for continuations, colons for introductions,
and hyphens for schedule placeholders.

https://claude.ai/code/session_017cjriCABmGCR1YujoVZZbG