### PR TITLE
Remove Aura 4 and Aura 5 from the rose page

### DIFF
--- a/src/components/sections/PathLevels.tsx
+++ b/src/components/sections/PathLevels.tsx
@@ -39,8 +39,8 @@ const stepVariants = {
   },
 };
 
-// Aura 2–5 are levels 5–8; their descriptions are hidden behind a toggle
-const COLLAPSED_LEVELS = new Set([5, 6, 7, 8]);
+// Aura 2–3 are levels 5–6; their descriptions are hidden behind a toggle
+const COLLAPSED_LEVELS = new Set([5, 6]);
 
 export default function PathLevels({ levels, variant = 'full', className }: PathLevelsProps) {
   const ref = useRef<HTMLElement>(null);

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -227,8 +227,8 @@ export const coherenceAlternatives: CoherenceAlternativeCategory[] = [
 
 // =============================================================================
 // PATH LEVELS (Rose Meditation 1–3 + Aura 1–5)
-// Full dataset kept for future use. Aura 4 & 5 (levels 7–8) are hidden from
-// the public UI via the visiblePathLevels export below.
+// Full dataset kept for reference. Aura 4 & 5 (levels 7–8) are excluded from
+// the rose page via the visiblePathLevels export below.
 // =============================================================================
 
 export const pathLevels: PathLevel[] = [
@@ -298,7 +298,9 @@ export const pathLevels: PathLevel[] = [
   },
 ];
 
-export const visiblePathLevels: PathLevel[] = pathLevels;
+export const visiblePathLevels: PathLevel[] = pathLevels.filter(
+  (l) => l.level <= 6,
+);
 
 // =============================================================================
 // LINEAGE


### PR DESCRIPTION
Filter visiblePathLevels to exclude levels 7-8 (Aura 4 & 5) so they
no longer appear on /the-rose. The full dataset is preserved in
pathLevels for use on other pages like /offerings.

https://claude.ai/code/session_01Bcd3ahzHv5s73fCsVxe54L