### PR TITLE
Remove architecture section from community page

### DIFF
--- a/src/app/(site)/community/page.tsx
+++ b/src/app/(site)/community/page.tsx
@@ -3,7 +3,6 @@
 import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import Link from 'next/link';
-import { cn } from '@/lib/utils';
 
 import PageHero from '@/components/sections/PageHero';
 import InvitationCTA from '@/components/sections/InvitationCTA';
@@ -67,65 +66,19 @@ export default function CommunityPage() {
               that coherence is contagious. That when one person remembers, it
               ripples through the field and touches everyone around them.
             </p>
+            <p>
+              <Link
+                href="/coherence"
+                className="underline underline-offset-4 decoration-[var(--color-rose-clay)] hover:text-[var(--color-foreground)] transition-colors duration-200"
+              >
+                Explore Coherence
+              </Link>
+            </p>
           </motion.div>
         </div>
       </section>
 
-      {/* 3. The Architecture — brief reference with link to Coherence */}
-      <section className="section-padding bg-[var(--color-background-subtle)]">
-        <div className="container-premium max-w-3xl mx-auto text-center">
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
-            className="label-sacred mb-6"
-          >
-            The Architecture
-          </motion.p>
-          <motion.h2
-            initial={{ opacity: 0, y: 24 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.1, ease: [0.16, 1, 0.3, 1] }}
-            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-6"
-          >
-            Built on Four Living Layers
-          </motion.h2>
-          <motion.p
-            initial={{ opacity: 0, y: 24 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2, ease: [0.16, 1, 0.3, 1] }}
-            className="text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8"
-          >
-            The community rests on a four-layer architecture: Hardware, Software,
-            Heartware, and Soulware, each sustaining a different dimension of
-            coherent living.
-          </motion.p>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.3, ease: [0.16, 1, 0.3, 1] }}
-          >
-            <Link
-              href="/coherence"
-              className={cn(
-                'inline-flex items-center gap-2',
-                'text-sm font-medium',
-                'text-[var(--color-foreground)]',
-                'underline underline-offset-4 decoration-[var(--color-rose-clay)]',
-                'hover:text-[var(--color-foreground-muted)]',
-                'transition-colors duration-200'
-              )}
-            >
-              Explore the full architecture in Coherence
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" />
-              </svg>
-            </Link>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* 4. How to Participate */}
+      {/* 3. How to Participate */}
       <section ref={participateRef} className="section-padding">
         <div className="container-premium max-w-3xl mx-auto">
           <motion.p
@@ -171,7 +124,7 @@ export default function CommunityPage() {
         </div>
       </section>
 
-      {/* 5. Invitation CTA */}
+      {/* 4. Invitation CTA */}
       <InvitationCTA />
     </>
   );


### PR DESCRIPTION
Replace the four-layer architecture section with an Explore Coherence
link at the end of the vision section. Clean up unused cn import.

https://claude.ai/code/session_01Ub1Uitcyd9WtDMXGY2TPFs