### PR TITLE
Add Aura Reading Level 2 (September 2026) course schedule

### DIFF
--- a/src/app/(site)/offerings/page.tsx
+++ b/src/app/(site)/offerings/page.tsx
@@ -4,7 +4,7 @@ import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { programs, scheduleStages, contributionTiers } from '@/lib/data';
+import { programs, scheduleStages, aura2ScheduleStages, contributionTiers } from '@/lib/data';
 
 import PageHero from '@/components/sections/PageHero';
 import ProgramCard from '@/components/sections/ProgramCard';
@@ -58,7 +58,7 @@ export default function OfferingsPage() {
         </div>
       </section>
 
-      {/* 3. Schedule */}
+      {/* 3. Schedule – The Rose + Aura 1 */}
       <section
         ref={scheduleRef}
         className="section-padding bg-[var(--color-background-subtle)]"
@@ -76,11 +76,38 @@ export default function OfferingsPage() {
             initial={{ opacity: 0, y: 24 }}
             animate={scheduleInView ? { opacity: 1, y: 0 } : {}}
             transition={{ duration: 0.6, delay: 0.1, ease: [0.16, 1, 0.3, 1] }}
-            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-8"
+            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-4"
           >
-            Program Schedule
+            The Rose + Aura 1
           </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 24 }}
+            animate={scheduleInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.15, ease: [0.16, 1, 0.3, 1] }}
+            className="text-sm text-[var(--color-foreground-muted)] mb-8"
+          >
+            March 17–27, 2026
+          </motion.p>
           <ScheduleTable stages={scheduleStages} />
+
+          {/* Aura Reading Level 2 */}
+          <motion.h2
+            initial={{ opacity: 0, y: 24 }}
+            animate={scheduleInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.2, ease: [0.16, 1, 0.3, 1] }}
+            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mt-16 mb-4"
+          >
+            Aura Reading Level 2
+          </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 24 }}
+            animate={scheduleInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.25, ease: [0.16, 1, 0.3, 1] }}
+            className="text-sm text-[var(--color-foreground-muted)] mb-8"
+          >
+            September 19–27, 2026
+          </motion.p>
+          <ScheduleTable stages={aura2ScheduleStages} />
         </div>
       </section>
 

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -12,6 +12,7 @@ export {
   guardians,
   programs,
   scheduleStages,
+  aura2ScheduleStages,
   contributionTiers,
   coherenceDomains,
   coherenceAlternatives,

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -83,6 +83,22 @@ export const programs: Program[] = [
       'Multi-timezone support',
     ],
   },
+  {
+    id: '2',
+    title: 'Aura Reading Level 2',
+    subtitle: 'Aura Reading Online Course Level 2',
+    duration: '9 days',
+    dates: 'September 19–27, 2026',
+    format: 'Live online',
+    description: 'Perception sharpens through theme readings and focused practice. Clairvoyance, clairsentience, and clairaudience refine as reading becomes more precise, nuanced, and confident. Weekend intensive classes combined with weekday practice sessions.',
+    includes: [
+      'Weekend intensive classes (4 days)',
+      'Weekday classes and practice sessions (5 days)',
+      'Daily Rose Meditation guidance',
+      'Flexible practice time slots',
+      'Multi-timezone support',
+    ],
+  },
 ];
 
 // =============================================================================
@@ -138,6 +154,34 @@ export const scheduleStages: ScheduleStage[] = [
     sessions: [
       { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '8:00 – 8:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
       { day: 'Q&A and Practice Time', duration: '3 hours', time: { sanJose: '8:00 – 11:00 AM', bogota: '9:00 AM – 12:00 PM', newYork: '10:00 AM – 1:00 PM', brasilia: '11:00 AM – 2:00 PM', london: '2:00 – 5:00 PM', madrid: '3:00 – 6:00 PM' } },
+    ],
+  },
+];
+
+// =============================================================================
+// AURA 2 SCHEDULE STAGES (September 19–27, 2026)
+// =============================================================================
+
+export const aura2ScheduleStages: ScheduleStage[] = [
+  {
+    id: 'aura2-1',
+    title: 'Aura Reading Level 2: Weekends',
+    dateRange: 'September 19, 20, 26 & 27 (Sat & Sun)',
+    sessions: [
+      { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '8:00 – 8:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
+      { day: 'First Class', duration: '2.5 hours', time: { sanJose: '8:00 – 10:30 AM', bogota: '9:00 – 11:30 AM', newYork: '9:00 – 11:30 AM', brasilia: '11:00 AM – 1:30 PM', london: '2:00 – 4:30 PM', madrid: '3:00 – 5:30 PM' } },
+      { day: 'Second Class', duration: '2.5 hours', time: { sanJose: '12:00 – 2:30 PM', bogota: '1:00 – 3:30 PM', newYork: '1:00 – 3:30 PM', brasilia: '3:00 – 5:30 PM', london: '6:00 – 8:30 PM', madrid: '7:00 – 9:30 PM' } },
+    ],
+  },
+  {
+    id: 'aura2-2',
+    title: 'Aura Reading Level 2: Weekdays',
+    dateRange: 'September 21–25 (Mon–Fri)',
+    sessions: [
+      { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '8:00 – 8:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
+      { day: 'First Practice (choose at least one)', duration: '1.5 hours', time: { sanJose: '8:00 – 9:30 AM', bogota: '9:00 – 10:30 AM', newYork: '9:00 – 10:30 AM', brasilia: '11:00 AM – 12:30 PM', london: '2:00 – 3:30 PM', madrid: '3:00 – 4:30 PM' } },
+      { day: 'Second Practice (choose at least one)', duration: '1.5 hours', time: { sanJose: '10:00 – 11:30 AM', bogota: '11:00 AM – 12:30 PM', newYork: '11:00 AM – 12:30 PM', brasilia: '1:00 – 2:30 PM', london: '4:00 – 5:30 PM', madrid: '5:00 – 6:30 PM' } },
+      { day: 'Class', duration: '1.5 hours', time: { sanJose: '12:00 – 1:30 PM', bogota: '1:00 – 2:30 PM', newYork: '1:00 – 2:30 PM', brasilia: '3:00 – 4:30 PM', london: '6:00 – 7:30 PM', madrid: '7:00 – 8:30 PM' } },
     ],
   },
 ];


### PR DESCRIPTION
Add program entry and schedule data for the Aura Reading Online
Course Level 2 running September 19-27, 2026. Includes weekend
intensive sessions (2.5h classes) and weekday practice/class
sessions with multi-timezone support. The offerings page now
displays both course schedules with separate headings.

https://claude.ai/code/session_013obsj7yoXu3LvnkyZdnd6h