### PR TITLE
Use contact page image on enrollment page

### DIFF
--- a/src/app/(forms)/enroll/page.tsx
+++ b/src/app/(forms)/enroll/page.tsx
@@ -42,7 +42,7 @@ export default function EnrollPage() {
           className="flex justify-center pointer-events-none"
         >
           <Image
-            src="/page-images/page-programs.png"
+            src="/page-images/page-contact.png"
             alt=""
             width={448}
             height={448}


### PR DESCRIPTION
Changed the enrollment page hero image from page-programs.png to
page-contact.png so both pages share the same image.

https://claude.ai/code/session_01LBAMxMNdiJaMErprxJLYbr