### PR TITLE
Remove shared agreements section from contact page

### DIFF
--- a/src/app/(site)/contact/page.tsx
+++ b/src/app/(site)/contact/page.tsx
@@ -3,7 +3,6 @@
 import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import { cn } from '@/lib/utils';
-import { agreements } from '@/lib/data';
 
 import PageHero from '@/components/sections/PageHero';
 
@@ -14,9 +13,6 @@ import PageHero from '@/components/sections/PageHero';
 export default function ContactPage() {
   const contentRef = useRef<HTMLElement>(null);
   const contentInView = useInView(contentRef, { once: true, margin: '-100px' });
-
-  const agreementsRef = useRef<HTMLElement>(null);
-  const agreementsInView = useInView(agreementsRef, { once: true, margin: '-100px' });
 
   return (
     <>
@@ -105,45 +101,6 @@ export default function ContactPage() {
         </div>
       </section>
 
-      {/* 3. Agreements */}
-      <section ref={agreementsRef} className="section-padding bg-[var(--color-background-subtle)]">
-        <div className="container-premium">
-          <div className="max-w-2xl mx-auto">
-            <motion.div
-              initial={{ opacity: 0, y: 24 }}
-              animate={agreementsInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
-            >
-              <p className="label-sacred mb-3 text-center">Agreements</p>
-              <h2 className="font-serif text-2xl tracking-tight mb-8 text-center">
-                Our Shared Agreements
-              </h2>
-
-              <div className="space-y-6">
-                {agreements.map((agreement, i) => (
-                  <motion.div
-                    key={agreement.id}
-                    initial={{ opacity: 0, y: 16 }}
-                    animate={agreementsInView ? { opacity: 1, y: 0 } : {}}
-                    transition={{
-                      duration: 0.5,
-                      delay: 0.1 + i * 0.08,
-                      ease: [0.16, 1, 0.3, 1],
-                    }}
-                  >
-                    <h3 className="font-serif text-lg tracking-tight mb-1">
-                      {agreement.title}
-                    </h3>
-                    <p className="text-sm text-[var(--color-foreground-muted)] leading-relaxed">
-                      {agreement.description}
-                    </p>
-                  </motion.div>
-                ))}
-              </div>
-            </motion.div>
-          </div>
-        </div>
-      </section>
     </>
   );
 }


### PR DESCRIPTION
The shared agreements section (listing commitment to practice, confidentiality,
respect for the lineage, personal responsibility, and community care) has been
removed from the contact page. The page now only contains the hero and direct
contact methods sections.

https://claude.ai/code/session_01DTJ7dP9gmVYbzmmEiSvJQA