### PR TITLE
Add aura quote to The Rose page after Aura Reading section

### DIFF
--- a/src/app/(site)/the-rose/page.tsx
+++ b/src/app/(site)/the-rose/page.tsx
@@ -265,6 +265,12 @@ export default function TheRosePage() {
         </div>
       </section>
 
+      {/* Quote — Aura */}
+      <QuoteBlock
+        quote="The aura is not just about colors. It contains all the information about who you truly are. You just need to learn how to see it."
+        variant="fullbleed"
+      />
+
       {/* 7. What This Journey Awakens in You */}
       <section className="section-padding">
         <div className="container-premium max-w-5xl mx-auto">


### PR DESCRIPTION
Adds a fullbleed QuoteBlock between the Aura Reading description
and the "What This Journey Awakens in You" section, bridging the
explanation of aura reading with its deeper purpose.

https://claude.ai/code/session_01MmG49qTsm8JfEhxXFeXghD