### PR TITLE
Simplify offering page: show schedule and contribution without dropdowns

### DIFF
--- a/src/app/(site)/offerings/page.tsx
+++ b/src/app/(site)/offerings/page.tsx
@@ -64,8 +64,6 @@ function OfferingsContent() {
   const [selectedProgramId, setSelectedProgramId] = useState<string | null>(
     null
   );
-  const [showContribution, setShowContribution] = useState(false);
-
   const gridRef = useRef<HTMLElement>(null);
   const gridInView = useInView(gridRef, { once: true, margin: '-100px' });
 
@@ -79,13 +77,9 @@ function OfferingsContent() {
 
   const handleProgramClick = (id: string) => {
     if (selectedProgramId === id) {
-      // Clicking the same program collapses everything
       setSelectedProgramId(null);
-      setShowContribution(false);
     } else {
-      // Select a new program, reset contribution
       setSelectedProgramId(id);
-      setShowContribution(false);
     }
   };
 
@@ -176,129 +170,74 @@ function OfferingsContent() {
                           />
                         </div>
 
-                        {/* View Contribution button */}
-                        <AnimatePresence>
-                          {!showContribution && (
-                            <motion.div
-                              initial={{ opacity: 0, y: 12 }}
-                              animate={{ opacity: 1, y: 0 }}
-                              exit={{ opacity: 0, y: -8 }}
-                              transition={{ duration: 0.3, ease }}
-                              className="flex justify-center py-4"
-                            >
-                              <button
-                                type="button"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setShowContribution(true);
-                                }}
-                                className={cn(
-                                  'inline-flex items-center gap-2 px-8 py-3.5 rounded-full',
-                                  'border-2 border-[var(--color-rose-clay)] text-[var(--color-rose-clay)]',
-                                  'text-sm font-medium',
-                                  'hover:bg-[var(--color-rose-clay)] hover:text-[var(--color-foreground-on-rose)]',
-                                  'transition-all duration-200',
-                                  'shadow-sm hover:shadow-md'
-                                )}
-                              >
-                                View Contribution
-                                <svg
-                                  className="w-4 h-4"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  strokeWidth={2}
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M19 9l-7 7-7-7"
-                                  />
-                                </svg>
-                              </button>
-                            </motion.div>
-                          )}
-                        </AnimatePresence>
-
                         {/* Contribution section */}
-                        <AnimatePresence>
-                          {showContribution && (
-                            <motion.div
-                              initial={{ opacity: 0, y: 24 }}
-                              animate={{ opacity: 1, y: 0 }}
-                              exit={{ opacity: 0, y: -12 }}
-                              transition={{ duration: 0.5, ease }}
-                            >
-                              <div className="pt-6 pb-4">
-                                <p className="label-sacred mb-3">
-                                  Contribution
-                                </p>
-                                <h3 className="font-serif text-[clamp(1.25rem,3vw,2rem)] leading-tight tracking-tight mb-3">
-                                  Income-Based Model
-                                </h3>
-                                <p className="text-base text-[var(--color-foreground-muted)] leading-relaxed mb-8 max-w-2xl">
-                                  We believe this work should be accessible to
-                                  everyone who is called. Our income-based
-                                  contribution model ensures that your financial
-                                  season is honored while sustaining the
-                                  ecosystem for all.
-                                </p>
-                                <ContributionTiers tiers={programTiers[program.id] || contributionTiers} />
-                                <p className="text-sm text-[var(--color-foreground-muted)] leading-relaxed mt-6 text-center italic">
-                                  Repeating a class? Your contribution is 50% of the original price.
-                                </p>
-                              </div>
+                        <div className="pt-6 pb-4">
+                          <p className="label-sacred mb-3">
+                            Contribution
+                          </p>
+                          <h3 className="font-serif text-[clamp(1.25rem,3vw,2rem)] leading-tight tracking-tight mb-3">
+                            Income-Based Model
+                          </h3>
+                          <p className="text-base text-[var(--color-foreground-muted)] leading-relaxed mb-8 max-w-2xl">
+                            We believe this work should be accessible to
+                            everyone who is called. Our income-based
+                            contribution model ensures that your financial
+                            season is honored while sustaining the
+                            ecosystem for all.
+                          </p>
+                          <ContributionTiers tiers={programTiers[program.id] || contributionTiers} />
+                          <p className="text-sm text-[var(--color-foreground-muted)] leading-relaxed mt-6 text-center italic">
+                            Repeating a class? Your contribution is 50% of the original price.
+                          </p>
+                        </div>
 
-                              {/* Enroll CTA */}
-                              <motion.div
-                                initial={{ opacity: 0, y: 16 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                transition={{
-                                  duration: 0.5,
-                                  delay: 0.3,
-                                  ease,
-                                }}
-                                className="text-center py-10"
-                              >
-                                <h3 className="font-serif text-[clamp(1.25rem,3vw,2rem)] leading-tight tracking-tight mb-3">
-                                  Ready to Begin?
-                                </h3>
-                                <p className="text-base text-[var(--color-foreground-muted)] leading-relaxed mb-6 max-w-lg mx-auto">
-                                  If something in these words resonates, we
-                                  invite you to take the next step. Enrollment
-                                  is open and we are here to support your
-                                  journey.
-                                </p>
-                                <Link
-                                  href={`/enroll?program=${program.id}`}
-                                  className={cn(
-                                    'inline-flex items-center gap-2 px-8 py-3.5 rounded-full',
-                                    'bg-[var(--color-accent)] text-[var(--color-accent-foreground)]',
-                                    'text-sm font-medium',
-                                    'hover:bg-[var(--color-accent-hover)]',
-                                    'transition-all duration-200',
-                                    'shadow-sm hover:shadow-md'
-                                  )}
-                                >
-                                  Enroll Now
-                                  <svg
-                                    className="w-4 h-4"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                    strokeWidth={2}
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      d="M17 8l4 4m0 0l-4 4m4-4H3"
-                                    />
-                                  </svg>
-                                </Link>
-                              </motion.div>
-                            </motion.div>
-                          )}
-                        </AnimatePresence>
+                        {/* Enroll CTA */}
+                        <motion.div
+                          initial={{ opacity: 0, y: 16 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{
+                            duration: 0.5,
+                            delay: 0.3,
+                            ease,
+                          }}
+                          className="text-center py-10"
+                        >
+                          <h3 className="font-serif text-[clamp(1.25rem,3vw,2rem)] leading-tight tracking-tight mb-3">
+                            Ready to Begin?
+                          </h3>
+                          <p className="text-base text-[var(--color-foreground-muted)] leading-relaxed mb-6 max-w-lg mx-auto">
+                            If something in these words resonates, we
+                            invite you to take the next step. Enrollment
+                            is open and we are here to support your
+                            journey.
+                          </p>
+                          <Link
+                            href={`/enroll?program=${program.id}`}
+                            className={cn(
+                              'inline-flex items-center gap-2 px-8 py-3.5 rounded-full',
+                              'bg-[var(--color-accent)] text-[var(--color-accent-foreground)]',
+                              'text-sm font-medium',
+                              'hover:bg-[var(--color-accent-hover)]',
+                              'transition-all duration-200',
+                              'shadow-sm hover:shadow-md'
+                            )}
+                          >
+                            Enroll Now
+                            <svg
+                              className="w-4 h-4"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={2}
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M17 8l4 4m0 0l-4 4m4-4H3"
+                              />
+                            </svg>
+                          </Link>
+                        </motion.div>
                       </motion.div>
                     )}
                   </AnimatePresence>

--- a/src/components/sections/ScheduleTable.tsx
+++ b/src/components/sections/ScheduleTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { motion, useInView, AnimatePresence } from 'framer-motion';
+import { motion, useInView } from 'framer-motion';
 import { ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { ScheduleStage } from '@/lib/data/types';
@@ -26,15 +26,6 @@ export default function ScheduleTable({ stages, className }: ScheduleTableProps)
   const ref = useRef<HTMLDivElement>(null);
   const isInView = useInView(ref, { once: true, margin: '-50px' });
   const [timezone, setTimezone] = useState<TimezoneKey>('newYork');
-  const [openStages, setOpenStages] = useState<string[]>(
-    stages.length > 0 ? [stages[0].id] : []
-  );
-
-  const toggleStage = (id: string) => {
-    setOpenStages((prev) =>
-      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
-    );
-  };
 
   return (
     <motion.div
@@ -76,125 +67,87 @@ export default function ScheduleTable({ stages, className }: ScheduleTableProps)
         </div>
       </div>
 
-      {/* Stages accordion */}
+      {/* Stages — all shown open */}
       <div className="space-y-3">
-        {stages.map((stage) => {
-          const isOpen = openStages.includes(stage.id);
+        {stages.map((stage) => (
+          <div
+            key={stage.id}
+            className={cn(
+              'border border-[var(--color-border)] rounded-xl overflow-hidden',
+              'bg-[var(--color-background-elevated)]',
+              'shadow-[var(--shadow-md)]'
+            )}
+          >
+            {/* Stage header */}
+            <div className="px-5 py-4 md:px-6 md:py-5">
+              <h3 className="font-serif text-lg md:text-xl text-[var(--color-foreground)] tracking-tight">
+                {stage.title}
+              </h3>
+              <p className="text-sm text-[var(--color-foreground-faint)] mt-0.5">
+                {stage.dateRange}
+              </p>
+            </div>
 
-          return (
-            <div
-              key={stage.id}
-              className={cn(
-                'border border-[var(--color-border)] rounded-xl overflow-hidden',
-                'bg-[var(--color-background-elevated)]',
-                'transition-shadow duration-300',
-                isOpen && 'shadow-[var(--shadow-md)]'
-              )}
-            >
-              {/* Stage header */}
-              <button
-                type="button"
-                onClick={() => toggleStage(stage.id)}
-                aria-expanded={isOpen}
-                className={cn(
-                  'flex w-full items-center justify-between',
-                  'px-5 py-4 md:px-6 md:py-5',
-                  'text-left',
-                  'hover:bg-[var(--color-background-subtle)]',
-                  'transition-colors duration-200',
-                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--color-rose-clay)]'
-                )}
-              >
-                <div>
-                  <h3 className="font-serif text-lg md:text-xl text-[var(--color-foreground)] tracking-tight">
-                    {stage.title}
-                  </h3>
-                  <p className="text-sm text-[var(--color-foreground-faint)] mt-0.5">
-                    {stage.dateRange}
-                  </p>
-                </div>
-                <motion.span
-                  animate={{ rotate: isOpen ? 180 : 0 }}
-                  transition={{ duration: 0.2, ease: 'easeOut' }}
-                  className="shrink-0 ml-4"
-                >
-                  <ChevronDown className="w-5 h-5 text-[var(--color-foreground-faint)]" />
-                </motion.span>
-              </button>
+            {/* Sessions content */}
+            <div className="px-5 pb-5 md:px-6 md:pb-6">
+              {/* Table header – hidden on mobile, shown on md+ */}
+              <div className="hidden md:grid grid-cols-[1.5fr_1fr_1.5fr] gap-4 pb-3 mb-3 border-b border-[var(--color-border-subtle)]">
+                <span className="label-sacred">Day</span>
+                <span className="label-sacred">Duration</span>
+                <span className="label-sacred">Time</span>
+              </div>
 
-              {/* Sessions content */}
-              <AnimatePresence initial={false}>
-                {isOpen && (
+              {/* Session rows */}
+              <div className="space-y-2">
+                {stage.sessions.map((session, idx) => (
                   <motion.div
-                    initial={{ height: 0, opacity: 0 }}
-                    animate={{ height: 'auto', opacity: 1 }}
-                    exit={{ height: 0, opacity: 0 }}
-                    transition={{ duration: 0.25, ease: 'easeOut' }}
-                    className="overflow-hidden"
+                    key={idx}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={isInView ? { opacity: 1, y: 0 } : {}}
+                    transition={{
+                      duration: 0.3,
+                      delay: idx * 0.04,
+                      ease: [0.16, 1, 0.3, 1],
+                    }}
+                    className={cn(
+                      'py-2.5 text-sm',
+                      idx < stage.sessions.length - 1 &&
+                        'border-b border-[var(--color-border-subtle)]'
+                    )}
                   >
-                    <div className="px-5 pb-5 md:px-6 md:pb-6">
-                      {/* Table header – hidden on mobile, shown on md+ */}
-                      <div className="hidden md:grid grid-cols-[1.5fr_1fr_1.5fr] gap-4 pb-3 mb-3 border-b border-[var(--color-border-subtle)]">
-                        <span className="label-sacred">Day</span>
-                        <span className="label-sacred">Duration</span>
-                        <span className="label-sacred">Time</span>
+                    {/* Mobile layout: stacked rows */}
+                    <div className="md:hidden">
+                      <div className="flex items-baseline justify-between gap-3">
+                        <span className="text-[var(--color-foreground-subtle)] font-medium">
+                          {session.day}
+                        </span>
+                        <span className="text-[var(--color-foreground-muted)] shrink-0">
+                          {session.duration}
+                        </span>
                       </div>
+                      <p className="text-[var(--color-foreground-faint)] tabular-nums text-xs mt-1">
+                        {session.time[timezone]}
+                      </p>
+                    </div>
 
-                      {/* Session rows */}
-                      <div className="space-y-2">
-                        {stage.sessions.map((session, idx) => (
-                          <motion.div
-                            key={idx}
-                            initial={{ opacity: 0, y: 8 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            transition={{
-                              duration: 0.3,
-                              delay: idx * 0.04,
-                              ease: [0.16, 1, 0.3, 1],
-                            }}
-                            className={cn(
-                              'py-2.5 text-sm',
-                              idx < stage.sessions.length - 1 &&
-                                'border-b border-[var(--color-border-subtle)]'
-                            )}
-                          >
-                            {/* Mobile layout: stacked rows */}
-                            <div className="md:hidden">
-                              <div className="flex items-baseline justify-between gap-3">
-                                <span className="text-[var(--color-foreground-subtle)] font-medium">
-                                  {session.day}
-                                </span>
-                                <span className="text-[var(--color-foreground-muted)] shrink-0">
-                                  {session.duration}
-                                </span>
-                              </div>
-                              <p className="text-[var(--color-foreground-faint)] tabular-nums text-xs mt-1">
-                                {session.time[timezone]}
-                              </p>
-                            </div>
-
-                            {/* Desktop layout: 3-column grid */}
-                            <div className="hidden md:grid grid-cols-[1.5fr_1fr_1.5fr] gap-4">
-                              <span className="text-[var(--color-foreground-subtle)] font-medium">
-                                {session.day}
-                              </span>
-                              <span className="text-[var(--color-foreground-muted)]">
-                                {session.duration}
-                              </span>
-                              <span className="text-[var(--color-foreground-faint)] tabular-nums whitespace-nowrap">
-                                {session.time[timezone]}
-                              </span>
-                            </div>
-                          </motion.div>
-                        ))}
-                      </div>
+                    {/* Desktop layout: 3-column grid */}
+                    <div className="hidden md:grid grid-cols-[1.5fr_1fr_1.5fr] gap-4">
+                      <span className="text-[var(--color-foreground-subtle)] font-medium">
+                        {session.day}
+                      </span>
+                      <span className="text-[var(--color-foreground-muted)]">
+                        {session.duration}
+                      </span>
+                      <span className="text-[var(--color-foreground-faint)] tabular-nums whitespace-nowrap">
+                        {session.time[timezone]}
+                      </span>
                     </div>
                   </motion.div>
-                )}
-              </AnimatePresence>
+                ))}
+              </div>
             </div>
-          );
-        })}
+          </div>
+        ))}
       </div>
     </motion.div>
   );


### PR DESCRIPTION
- Remove accordion toggle from schedule stages so all sessions are
  visible immediately without clicking to expand
- Remove "View Contribution" button gate so contribution tiers display
  directly after the schedule section
- Remove showContribution state and related logic

https://claude.ai/code/session_01Xkqc89FwBm9NJ63JNpxtKD