### PR TITLE
Bold "it restores awareness/coherence/real choice" on rose page

### DIFF
--- a/src/app/(site)/the-rose/page.tsx
+++ b/src/app/(site)/the-rose/page.tsx
@@ -116,8 +116,10 @@ export default function TheRosePage() {
         title="What the Rose Is"
       >
         <p>
-          The Rose is a simple, living inner technology. It restores awareness.
-          It restores coherence. It restores real choice.
+          The Rose is a simple, living inner technology.{' '}
+          <span className="font-medium text-[var(--color-foreground)]">It restores awareness.</span>{' '}
+          <span className="font-medium text-[var(--color-foreground)]">It restores coherence.</span>{' '}
+          <span className="font-medium text-[var(--color-foreground)]">It restores real choice.</span>
         </p>
         <p>
           It doesn&apos;t fight the noise and fragmentation. It quietly


### PR DESCRIPTION
Apply font-medium text styling to the three "it restores" phrases in the
"What the Rose Is" section, matching the bold treatment used on the two
questions below.

https://claude.ai/code/session_01Vz2zyFxWVGaWBqTPJFnkFA