### PR TITLE
Fix vertical rose cutoff on mobile (iPhone)

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -673,7 +673,7 @@ export default function Home() {
         </div>
 
         {/* 3D Rose Model */}
-        <div className="relative w-full h-[38vh] sm:h-[42vh] md:h-[50vh] lg:h-[55vh] xl:h-[60vh] mt-2 sm:mt-0 md:-mt-2 lg:-mt-4 pointer-events-none">
+        <div className="relative w-full h-[44vh] sm:h-[46vh] md:h-[50vh] lg:h-[55vh] xl:h-[60vh] mt-2 sm:mt-0 md:-mt-2 lg:-mt-4 pointer-events-none">
           <HeroSphere />
         </div>
 

--- a/src/components/three/RoseModel.tsx
+++ b/src/components/three/RoseModel.tsx
@@ -75,8 +75,8 @@ export default function RoseModel({ mouseRef, reducedMotion, isDark }: RoseModel
   // Rose fills ~85% of the smaller viewport dimension so it's always visible.
   useEffect(() => {
     const vMin = Math.min(viewport.width, viewport.height);
-    // Fill 96% of the smaller dimension — as large as possible without clipping
-    const scale = (vMin * 0.96) / maxDim;
+    // Fill 84% of the smaller dimension — enough breathing room to avoid mobile clipping
+    const scale = (vMin * 0.84) / maxDim;
     model.position.set(
       -centerOffset.x * scale,
       -centerOffset.y * scale,


### PR DESCRIPTION
Increase mobile rose container height from 38vh to 44vh and reduce
rose scale factor from 96% to 84% so the model has breathing room
within the overflow-hidden hero section.

https://claude.ai/code/session_01NB45gMD3nFboZwNF85qHpn