### PR TITLE
Lower rose position and extend scroll dissolve duration on hero section

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -507,8 +507,8 @@ export default function Home() {
     offset: ['start start', 'end start'],
   });
 
-  const heroOpacity = useTransform(scrollYProgress, [0, 0.5], [1, 0]);
-  const heroY = useTransform(scrollYProgress, [0, 0.5], [0, -60]);
+  const heroOpacity = useTransform(scrollYProgress, [0, 0.75], [1, 0]);
+  const heroY = useTransform(scrollYProgress, [0, 0.75], [0, -60]);
 
   // Preloader coordination
   const [ready, setReady] = useState(false);
@@ -673,7 +673,7 @@ export default function Home() {
         </div>
 
         {/* 3D Rose Model */}
-        <div className="relative w-full h-[44vh] sm:h-[46vh] md:h-[50vh] lg:h-[55vh] xl:h-[60vh] mt-2 sm:mt-0 md:-mt-2 lg:-mt-4 pointer-events-none">
+        <div className="relative w-full h-[44vh] sm:h-[46vh] md:h-[50vh] lg:h-[55vh] xl:h-[60vh] mt-2 sm:mt-0 md:mt-2 lg:mt-4 pointer-events-none">
           <HeroSphere />
         </div>
 


### PR DESCRIPTION
Move the 3D rose container down by changing negative margins (md:-mt-2
lg:-mt-4) to positive margins (md:mt-2 lg:mt-4) so it doesn't crowd
the CTA buttons on MacBook Air. Extend the scroll dissolve range from
[0, 0.5] to [0, 0.75] so the hero content and buttons stay visible
longer while scrolling.

https://claude.ai/code/session_01H1dPcQE44X8a1UxpiWUsfK