### PR TITLE
Update offerings page, contribution tiers, and community labels

### DIFF
--- a/src/components/sections/ProgramCard.tsx
+++ b/src/components/sections/ProgramCard.tsx
@@ -87,7 +87,16 @@ export default function ProgramCard({
         )}
       </div>
 
-      {/* Description, Meta & Includes — hidden in compact mode */}
+      {/* Description — always visible so first-time visitors see what each course offers */}
+      {program.description && (
+        <div className={cn('text-base md:text-lg text-[var(--color-foreground-muted)] leading-relaxed space-y-4', compact ? 'mt-4' : 'mb-8')}>
+          {program.description.split('\n\n').map((paragraph, i) => (
+            <p key={i}>{paragraph}</p>
+          ))}
+        </div>
+      )}
+
+      {/* Meta & Includes — hidden in compact mode */}
       <AnimatePresence>
         {!compact && (
           <motion.div
@@ -97,15 +106,6 @@ export default function ProgramCard({
             transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
             className="overflow-hidden"
           >
-            {/* Description — shown first and prominently */}
-            {program.description && (
-              <div className="text-base md:text-lg text-[var(--color-foreground-muted)] leading-relaxed mb-8 space-y-4">
-                {program.description.split('\n\n').map((paragraph, i) => (
-                  <p key={i}>{paragraph}</p>
-                ))}
-              </div>
-            )}
-
             {/* When progressiveDetails is on, wrap meta & includes behind a toggle */}
             {progressiveDetails ? (
               <>

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -67,7 +67,7 @@ export const guardians: Guardian[] = [
 export const programs: Program[] = [
   {
     id: '3',
-    title: 'The Rose',
+    title: 'Rose Meditation',
     subtitle: 'Level 1, 2, 3',
     duration: '2 days',
     dates: 'March 17–18, 2026',
@@ -227,21 +227,21 @@ export const contributionTiers: ContributionTier[] = [
   {
     id: '1',
     name: 'Seed',
-    range: 'Under $30,000 USD annual income',
+    range: 'Lower income range',
     description: 'A lower contribution that honors your reality and current season.',
     price: '$888',
   },
   {
     id: '2',
     name: 'Bloom',
-    range: '$30,000–$70,000 USD annual income',
+    range: 'Middle income range',
     description: 'A mid-range contribution reflecting reciprocity and balance.',
     price: '$1,444',
   },
   {
     id: '3',
     name: 'Canopy',
-    range: 'Above $70,000 USD annual income',
+    range: 'Higher income range',
     description: 'A higher tier that supports accessibility for others and the expansion of this work.',
     price: '$2,111',
   },
@@ -255,21 +255,21 @@ export const roseMeditationTiers: ContributionTier[] = [
   {
     id: 'rose-1',
     name: 'Seed',
-    range: 'Under $30,000 USD annual income',
+    range: 'Lower income range',
     description: 'A lower contribution that honors your reality and current season.',
     price: '$222',
   },
   {
     id: 'rose-2',
     name: 'Bloom',
-    range: '$30,000–$70,000 USD annual income',
+    range: 'Middle income range',
     description: 'A mid-range contribution reflecting reciprocity and balance.',
     price: '$444',
   },
   {
     id: 'rose-3',
     name: 'Canopy',
-    range: 'Above $70,000 USD annual income',
+    range: 'Higher income range',
     description: 'A higher tier that supports accessibility for others and the expansion of this work.',
     price: '$777',
   },
@@ -546,7 +546,7 @@ export const freePrograms: CommunityProgram[] = [
     id: 'free-live-guidances',
     title: 'Free Live Guidances',
     description: 'Live Rose Meditation guidances offered to all who have already been initiated in Rose Meditation. A space to deepen your practice with the support of a guided session and the collective field.',
-    audience: 'For those already initiated in Rose Meditation',
+    audience: 'Rose Meditation Practitioner',
     free: true,
   },
   {


### PR DESCRIPTION
- Show course descriptions in compact/collapsed card view on offerings page
  so first-time visitors see what each program is about without needing to click
- Rename "The Rose" course to "Rose Meditation"
- Remove specific salary range numbers ($30,000-$70,000) from all contribution
  tiers, replacing with cleaner "Lower/Middle/Higher income range" labels
- Change free live guidance audience label from "For those already initiated
  in Rose Meditation" to "Rose Meditation Practitioner"

https://claude.ai/code/session_01Q7LEFD37docgQnMPTuZy1u