### PR TITLE
Add expandable 2026 schedule and investment details to community programs

### DIFF
--- a/src/app/(site)/community/page.tsx
+++ b/src/app/(site)/community/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useRef } from 'react';
-import { motion, useInView } from 'framer-motion';
+import { useRef, useState } from 'react';
+import { motion, useInView, AnimatePresence } from 'framer-motion';
+import { ChevronDown } from 'lucide-react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { freePrograms, paidPrograms } from '@/lib/data';
@@ -24,11 +25,17 @@ function ActivityCard({
   program,
   index,
   inView,
+  expanded,
+  onToggle,
 }: {
   program: CommunityProgram;
   index: number;
   inView: boolean;
+  expanded?: boolean;
+  onToggle?: () => void;
 }) {
+  const hasDetails = program.scheduleCycles || program.investment;
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 24 }}
@@ -41,7 +48,8 @@ function ActivityCard({
         'border border-rose-200/50 dark:border-rose-800/20',
         'hover:border-rose-300 dark:hover:border-rose-700/40',
         'hover:shadow-lg hover:shadow-rose-500/5',
-        'transition-all duration-500'
+        'transition-all duration-500',
+        expanded && 'border-rose-300 dark:border-rose-700/40 shadow-lg shadow-rose-500/5'
       )}
     >
       <h3 className="font-serif text-[clamp(1.15rem,2.5vw,1.5rem)] leading-tight tracking-tight mb-3 text-[var(--color-foreground)]">
@@ -159,6 +167,28 @@ function ActivityCard({
           )}
         </div>
       )}
+
+      {/* View Details toggle for programs with schedule/investment */}
+      {hasDetails && onToggle && (
+        <button
+          onClick={onToggle}
+          className={cn(
+            'mt-6 inline-flex items-center gap-2',
+            'text-sm font-medium',
+            'text-[var(--color-foreground-muted)]',
+            'hover:text-[var(--color-foreground)]',
+            'transition-colors duration-200'
+          )}
+        >
+          {expanded ? 'Hide Schedule & Investment' : 'View 2026 Schedule & Investment'}
+          <ChevronDown
+            className={cn(
+              'w-4 h-4 transition-transform duration-300',
+              expanded && 'rotate-180'
+            )}
+          />
+        </button>
+      )}
     </motion.div>
   );
 }
@@ -168,6 +198,8 @@ function ActivityCard({
 // =============================================================================
 
 export default function CommunityPage() {
+  const [expandedProgramId, setExpandedProgramId] = useState<string | null>(null);
+
   const visionRef = useRef<HTMLElement>(null);
   const visionInView = useInView(visionRef, { once: true, margin: '-100px' });
 
@@ -176,6 +208,10 @@ export default function CommunityPage() {
 
   const paidRef = useRef<HTMLElement>(null);
   const paidInView = useInView(paidRef, { once: true, margin: '-100px' });
+
+  const handleToggle = (id: string) => {
+    setExpandedProgramId((prev) => (prev === id ? null : id));
+  };
 
   return (
     <>
@@ -305,14 +341,137 @@ export default function CommunityPage() {
             work at a deeper level.
           </motion.p>
           <div className="space-y-4">
-            {paidPrograms.map((program, i) => (
-              <ActivityCard
-                key={program.id}
-                program={program}
-                index={i}
-                inView={paidInView}
-              />
-            ))}
+            {paidPrograms.map((program, i) => {
+              const isExpanded = expandedProgramId === program.id;
+
+              return (
+                <div key={program.id}>
+                  <ActivityCard
+                    program={program}
+                    index={i}
+                    inView={paidInView}
+                    expanded={isExpanded}
+                    onToggle={() => handleToggle(program.id)}
+                  />
+
+                  {/* Expanded: Schedule + Investment */}
+                  <AnimatePresence>
+                    {isExpanded && (
+                      <motion.div
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        exit={{ opacity: 0, height: 0 }}
+                        transition={{ duration: 0.5, ease }}
+                        className="overflow-hidden"
+                      >
+                        {/* Schedule section */}
+                        {program.scheduleCycles && (
+                          <div className="mt-8 mb-8">
+                            <p className="label-sacred mb-3">Schedule</p>
+                            <h3 className="font-serif text-[clamp(1.25rem,3vw,2rem)] leading-tight tracking-tight mb-2">
+                              2026 Class Schedule
+                            </h3>
+                            <p className="text-sm text-[var(--color-foreground-muted)] mb-6">
+                              All times shown in Costa Rica time (CST)
+                            </p>
+
+                            <div className="space-y-4">
+                              {program.scheduleCycles.map((cycle) => (
+                                <div
+                                  key={cycle.id}
+                                  className={cn(
+                                    'border border-[var(--color-border)] rounded-xl overflow-hidden',
+                                    'bg-[var(--color-background-elevated)]',
+                                    'shadow-[var(--shadow-md)]'
+                                  )}
+                                >
+                                  {/* Cycle header */}
+                                  <div className="px-5 py-4 md:px-6 md:py-5">
+                                    <h4 className="font-serif text-lg md:text-xl text-[var(--color-foreground)] tracking-tight">
+                                      {cycle.title}
+                                    </h4>
+                                  </div>
+
+                                  {/* Month groups */}
+                                  <div className="px-5 pb-5 md:px-6 md:pb-6">
+                                    {cycle.months.map((month, monthIdx) => (
+                                      <div key={month.month} className={cn(monthIdx > 0 && 'mt-4')}>
+                                        <p className="label-sacred mb-2 text-xs">
+                                          {month.month}
+                                        </p>
+                                        <div className="space-y-1">
+                                          {month.sessions.map((session, sIdx) => (
+                                            <div
+                                              key={sIdx}
+                                              className={cn(
+                                                'flex items-baseline justify-between gap-3 py-2 text-sm',
+                                                sIdx < month.sessions.length - 1 &&
+                                                  'border-b border-[var(--color-border-subtle)]'
+                                              )}
+                                            >
+                                              <span className="text-[var(--color-foreground-subtle)] font-medium">
+                                                {session.date}
+                                              </span>
+                                              <span className="text-[var(--color-foreground-muted)] tabular-nums shrink-0">
+                                                {session.time}
+                                              </span>
+                                            </div>
+                                          ))}
+                                        </div>
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Investment section */}
+                        {program.investment && (
+                          <div className="pt-6 pb-4">
+                            <p className="label-sacred mb-3">Investment</p>
+                            <h3 className="font-serif text-[clamp(1.25rem,3vw,2rem)] leading-tight tracking-tight mb-6">
+                              {program.title}
+                            </h3>
+
+                            <div className={cn(
+                              'grid gap-4',
+                              program.investment.length === 3
+                                ? 'sm:grid-cols-3'
+                                : 'sm:grid-cols-2'
+                            )}>
+                              {program.investment.map((option) => (
+                                <div
+                                  key={option.id}
+                                  className={cn(
+                                    'rounded-xl p-5',
+                                    'border border-[var(--color-border)]',
+                                    'bg-[var(--color-background-elevated)]',
+                                    'shadow-[var(--shadow-md)]',
+                                    'text-center'
+                                  )}
+                                >
+                                  <p className="font-serif text-lg text-[var(--color-foreground)] mb-1">
+                                    {option.label}
+                                  </p>
+                                  <p className="text-xs text-[var(--color-foreground-faint)] mb-3">
+                                    {option.period}
+                                  </p>
+                                  <p className="font-serif text-2xl text-[var(--color-foreground)] tracking-tight">
+                                    {option.price}
+                                  </p>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              );
+            })}
           </div>
 
           {/* CTA to Offerings */}

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -6,6 +6,8 @@ export type {
   ArchitectureLayer, Chakra, Technique, TeachingLevel,
   Agreement, Capacity, MessagingPillar, BrandQuote, Stat,
   CommunityProgram,
+  CommunityClassSession, CommunityScheduleMonth,
+  CommunityScheduleCycle, InvestmentOption,
 } from './types';
 
 export {

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -8,6 +8,7 @@ import type {
   PathLevel, LineageEntry,
   ArchitectureLayer, Chakra, Technique, TeachingLevel,
   Agreement, Capacity, BrandQuote, Stat, CommunityProgram,
+  CommunityScheduleCycle, InvestmentOption,
 } from './types';
 
 // =============================================================================
@@ -547,6 +548,7 @@ export const freePrograms: CommunityProgram[] = [
     id: 'free-live-guidances',
     title: 'Free Live Guidances',
     description: 'Live Rose Meditation guidances offered to all who have already been initiated in Rose Meditation. A space to deepen your practice with the support of a guided session and the collective field.',
+    schedule: 'Every Saturday, 9:30 AM – 10:00 AM (Costa Rica time)',
     audience: 'Rose Meditation Practitioner',
     free: true,
     whatsappLink: 'https://chat.whatsapp.com/Lh6bJlDmliMIryvKz63tzi?mode=gi_t',
@@ -562,6 +564,255 @@ export const freePrograms: CommunityProgram[] = [
   },
 ];
 
+// =============================================================================
+// COMMUNITY: TEACHERS TRAINING — 2026 SCHEDULE
+// =============================================================================
+
+export const teachersTrainingSchedule: CommunityScheduleCycle[] = [
+  {
+    id: 'tt-intro',
+    title: 'Introduction Class',
+    months: [
+      {
+        month: 'February',
+        sessions: [
+          { date: 'Wed, Feb 25', time: '12:00 – 1:30 pm' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'tt-program-1',
+    title: 'Program 1 | March to July',
+    months: [
+      {
+        month: 'March',
+        sessions: [
+          { date: 'Fri, Mar 6', time: '3:00 – 4:30 pm' },
+          { date: 'Thu, Mar 12', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Mar 19', time: '11:00 – 12:30 pm' },
+          { date: 'Thu, Mar 26', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'April',
+        sessions: [
+          { date: 'Thu, Apr 2', time: '11:00 – 12:30 pm' },
+          { date: 'Thu, Apr 16', time: '12:00 – 1:30 pm' },
+          { date: 'Wed, Apr 22', time: '3:00 – 4:30 pm' },
+          { date: 'Thu, Apr 30', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'May',
+        sessions: [
+          { date: 'Mon, May 4', time: '4:00 – 5:30 pm' },
+          { date: 'Thu, May 14', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, May 21', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, May 28', time: '1:00 – 2:30 pm' },
+        ],
+      },
+      {
+        month: 'June',
+        sessions: [
+          { date: 'Thu, Jun 4', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Jun 11', time: '11:00 – 12:30 pm' },
+          { date: 'Thu, Jun 18', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Jun 25', time: '1:00 – 2:00 pm' },
+        ],
+      },
+      {
+        month: 'July',
+        sessions: [
+          { date: 'Thu, Jul 2', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Jul 9', time: '12:00 – 1:30 pm' },
+          { date: 'Mon, Jul 20', time: '3:00 – 4:30 pm' },
+          { date: 'Thu, Jul 30', time: '3:00 – 4:30 pm' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'tt-program-2',
+    title: 'Program 2 | August to December',
+    months: [
+      {
+        month: 'August',
+        sessions: [
+          { date: 'Thu, Aug 6', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Aug 13', time: '1:00 – 2:30 pm' },
+          { date: 'Thu, Aug 20', time: '11:00 – 12:30 pm' },
+          { date: 'Thu, Aug 27', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'September',
+        sessions: [
+          { date: 'Thu, Sep 3', time: '11:00 – 12:30 pm' },
+          { date: 'Thu, Sep 10', time: '1:00 – 2:30 pm' },
+          { date: 'Thu, Sep 17', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Sep 24', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'October',
+        sessions: [
+          { date: 'Wed, Oct 7', time: '1:00 – 2:30 pm' },
+          { date: 'Thu, Oct 15', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Oct 22', time: '11:00 – 12:30 pm' },
+          { date: 'Thu, Oct 29', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'November',
+        sessions: [
+          { date: 'Thu, Nov 5', time: '11:00 – 12:30 pm' },
+          { date: 'Thu, Nov 12', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Nov 19', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Nov 26', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'December',
+        sessions: [
+          { date: 'Thu, Dec 3', time: '12:00 – 1:30 pm' },
+          { date: 'Thu, Dec 10', time: '12:00 – 1:30 pm' },
+          { date: 'Mon, Dec 14', time: '1:00 – 2:00 pm' },
+        ],
+      },
+    ],
+  },
+];
+
+export const teachersTrainingInvestment: InvestmentOption[] = [
+  { id: 'tt-cycle-1', label: 'First Cycle of Training', period: 'March to July', price: '$600' },
+  { id: 'tt-cycle-2', label: 'Second Cycle of Training', period: 'August to December', price: '$600' },
+];
+
+// =============================================================================
+// COMMUNITY: AURA FOR LIFE — 2026 SCHEDULE
+// =============================================================================
+
+export const auraForLifeSchedule: CommunityScheduleCycle[] = [
+  {
+    id: 'afl-cycle-1',
+    title: 'Cycle 1 | February to July',
+    months: [
+      {
+        month: 'February',
+        sessions: [
+          { date: 'Tue, Feb 24', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'March',
+        sessions: [
+          { date: 'Tue, Mar 3', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Mar 10', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Mar 17', time: '11:00 – 12:30 pm' },
+          { date: 'Tue, Mar 24', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'April',
+        sessions: [
+          { date: 'Tue, Apr 7', time: '11:00 – 12:30 pm' },
+          { date: 'Tue, Apr 14', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Apr 21', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Apr 28', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'May',
+        sessions: [
+          { date: 'Tue, May 5', time: '1:00 – 2:30 pm' },
+          { date: 'Tue, May 12', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, May 19', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, May 26', time: '11:00 – 12:30 pm' },
+        ],
+      },
+      {
+        month: 'June',
+        sessions: [
+          { date: 'Tue, Jun 9', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Jun 16', time: '12:00 – 1:30 pm' },
+          { date: 'Wed, Jun 24', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Jun 30', time: '11:00 – 12:30 pm' },
+        ],
+      },
+      {
+        month: 'July',
+        sessions: [
+          { date: 'Tue, Jul 7', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Jul 21', time: '3:00 – 4:30 pm' },
+          { date: 'Thu, Jul 23', time: '3:00 – 4:30 pm' },
+          { date: 'Tue, Jul 28', time: '3:00 – 4:30 pm' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'afl-cycle-2',
+    title: 'Cycle 2 | August to December',
+    months: [
+      {
+        month: 'August',
+        sessions: [
+          { date: 'Wed, Aug 5', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Aug 11', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Aug 18', time: '11:00 – 12:30 pm' },
+          { date: 'Tue, Aug 25', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'September',
+        sessions: [
+          { date: 'Tue, Sep 1', time: '11:00 – 12:30 pm' },
+          { date: 'Tue, Sep 8', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Sep 15', time: '1:00 – 2:30 pm' },
+          { date: 'Tue, Sep 22', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'October',
+        sessions: [
+          { date: 'Thu, Oct 1', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Oct 6', time: '11:00 – 12:30 pm' },
+          { date: 'Tue, Oct 20', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Oct 27', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'November',
+        sessions: [
+          { date: 'Tue, Nov 3', time: '11:00 – 12:30 pm' },
+          { date: 'Tue, Nov 10', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Nov 17', time: '1:00 – 2:30 pm' },
+          { date: 'Tue, Nov 24', time: '12:00 – 1:30 pm' },
+        ],
+      },
+      {
+        month: 'December',
+        sessions: [
+          { date: 'Tue, Dec 1', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Dec 8', time: '12:00 – 1:30 pm' },
+          { date: 'Tue, Dec 15', time: '12:00 – 1:00 pm' },
+        ],
+      },
+    ],
+  },
+];
+
+export const auraForLifeInvestment: InvestmentOption[] = [
+  { id: 'afl-cycle-1', label: 'Cycle 1', period: 'March to July', price: '$400' },
+  { id: 'afl-cycle-2', label: 'Cycle 2', period: 'August to December', price: '$400' },
+  { id: 'afl-full', label: 'Full Cycle', period: 'March to December', price: '$700' },
+];
+
+// =============================================================================
+// ONGOING COMMUNITY PROGRAMS & ACTIVITIES (with schedule + investment)
+// =============================================================================
+
 export const paidPrograms: CommunityProgram[] = [
   {
     id: 'aura-for-life',
@@ -570,6 +821,8 @@ export const paidPrograms: CommunityProgram[] = [
     free: false,
     whatsappLink: 'https://chat.whatsapp.com/BeowpnN4CtvJdqFysxxy41',
     calendarLink: 'https://calendar.google.com/calendar/ical/d28269c09ef556ca45935fd59f6846c0208ae9e4681e870445fffbe011216491%40group.calendar.google.com/public/basic.ics',
+    scheduleCycles: auraForLifeSchedule,
+    investment: auraForLifeInvestment,
   },
   {
     id: 'teachers-training',
@@ -577,5 +830,7 @@ export const paidPrograms: CommunityProgram[] = [
     description: 'A dedicated training path for those called to share Rose Meditation with others. This program prepares you to hold space, guide meditations, and transmit the practice with clarity, presence, and integrity.',
     free: false,
     calendarLink: 'https://calendar.google.com/calendar/ical/6c5be92eae7703c042356edb50cd679ab042ac4ddb5ca8ca68f9b37f77df9de8%40group.calendar.google.com/public/basic.ics',
+    scheduleCycles: teachersTrainingSchedule,
+    investment: teachersTrainingInvestment,
   },
 ];

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -174,6 +174,33 @@ export interface Stat {
   label: string;
 }
 
+/** Community program class session (date + time) */
+export interface CommunityClassSession {
+  date: string;
+  time: string;
+}
+
+/** Community program schedule month */
+export interface CommunityScheduleMonth {
+  month: string;
+  sessions: CommunityClassSession[];
+}
+
+/** Community program schedule cycle (group of months) */
+export interface CommunityScheduleCycle {
+  id: string;
+  title: string;
+  months: CommunityScheduleMonth[];
+}
+
+/** Investment option for community programs */
+export interface InvestmentOption {
+  id: string;
+  label: string;
+  period: string;
+  price: string;
+}
+
 /** Ongoing community program or activity */
 export interface CommunityProgram {
   id: string;
@@ -184,4 +211,6 @@ export interface CommunityProgram {
   free: boolean;
   whatsappLink?: string;
   calendarLink?: string;
+  scheduleCycles?: CommunityScheduleCycle[];
+  investment?: InvestmentOption[];
 }


### PR DESCRIPTION
Adds schedule (grouped by cycle/month) and pricing information for
Aura for Life and Teachers Training, displayed via expand/collapse
following the same progressive disclosure pattern as the offerings page.

https://claude.ai/code/session_01LsFQ267reZ7jZfArYx22jU