### PR TITLE
Rename Subscribe button to Add to Calendar, move Community before Guardians in nav

### DIFF
--- a/src/components/ui/SubscribeCalendar.tsx
+++ b/src/components/ui/SubscribeCalendar.tsx
@@ -126,7 +126,7 @@ export default function SubscribeCalendar({ googleCalendarUrl, icsUrl }: Subscri
             d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
           />
         </svg>
-        Subscribe to Calendar
+        Add to Calendar
         <svg
           className={cn('w-3 h-3 transition-transform duration-200', open && 'rotate-180')}
           fill="none"

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -18,8 +18,8 @@ import type {
 export const navItems: NavItem[] = [
   { label: 'The Rose', href: '/the-rose' },
   { label: 'Offerings', href: '/offerings' },
-  { label: 'Guardians', href: '/guardians' },
   { label: 'Community', href: '/community' },
+  { label: 'Guardians', href: '/guardians' },
 ];
 
 // =============================================================================


### PR DESCRIPTION
- Changed "Subscribe to Calendar" → "Add to Calendar" for standard UX convention
- Reordered navigation: Community now appears before Guardians to follow
  the natural user journey (product → offerings → community → team)

https://claude.ai/code/session_01SNSDxLsRm1MXA7MsTaksqf