### PR TITLE
Add actual translations for Portuguese, Spanish, and Greek teaching c…

### DIFF
--- a/src/content/teaching/el.json
+++ b/src/content/teaching/el.json
@@ -1,350 +1,349 @@
 {
   "ui": {
-    "teacherVisualAidManual": "Teacher Visual Aid Manual",
-    "facilitatorCompanion": "A facilitator’s visual companion for teaching Rose Meditation.",
-    "selectTeachingLevel": "Select a Teaching Level",
-    "allLevels": "All Levels",
-    "level": "Level",
-    "slide": "Slide",
-    "designerNote": "Designer note",
-    "downloadPdf": "Download PDF",
-    "sacredSpace": "Sacred Space",
-    "theChakraSystem": "The Chakra System",
-    "cleansingAndRecovery": "Cleansing & Recovery",
-    "goldenStickyRoses": "Golden Sticky Roses",
-    "balancedExpression": "Balanced Expression",
-    "unbalancedExpression": "Unbalanced Expression",
-    "primaryBlockages": "Primary Blockages",
-    "color": "Color",
-    "element": "Element",
-    "location": "Location",
-    "energy": "Energy",
-    "focus": "Focus",
-    "lineage": "Lineage",
+    "teacherVisualAidManual": "Οπτικό Εγχειρίδιο για Δασκάλους",
+    "facilitatorCompanion": "Ένας οπτικός σύντροφος του εκπαιδευτή για τη διδασκαλία του Διαλογισμού του Τριαντάφυλλου.",
+    "selectTeachingLevel": "Επιλέξτε Επίπεδο Διδασκαλίας",
+    "allLevels": "Όλα τα Επίπεδα",
+    "level": "Επίπεδο",
+    "slide": "Διαφάνεια",
+    "designerNote": "Σημείωση σχεδιαστή",
+    "downloadPdf": "Λήψη PDF",
+    "sacredSpace": "Ιερός Χώρος",
+    "theChakraSystem": "Το Σύστημα των Τσάκρα",
+    "cleansingAndRecovery": "Καθαρισμός και Ανάκτηση",
+    "goldenStickyRoses": "Χρυσά Κολλώδη Τριαντάφυλλα",
+    "balancedExpression": "Ισορροπημένη Έκφραση",
+    "unbalancedExpression": "Ανισόρροπη Έκφραση",
+    "primaryBlockages": "Κύρια Μπλοκαρίσματα",
+    "color": "Χρώμα",
+    "element": "Στοιχείο",
+    "location": "Τοποθεσία",
+    "energy": "Ενέργεια",
+    "focus": "Εστίαση",
+    "lineage": "Καταγωγή",
     "rosesOs": "ROSES OS"
   },
   "opening": {
     "agreements": {
-      "title": "Agreements & Virtues",
-      "text": "Before beginning, all participants honor these agreements:",
+      "title": "Συμφωνίες και Αρετές",
+      "text": "Πριν ξεκινήσουμε, όλοι οι συμμετέχοντες τιμούν αυτές τις συμφωνίες:",
       "items": [
-        "Punctuality",
-        "Confidentiality",
-        "Co-responsibility",
-        "Trust",
-        "Patience, Empathy and Compassion"
+        "Συνέπεια",
+        "Εμπιστευτικότητα",
+        "Συνυπευθυνότητα",
+        "Εμπιστοσύνη",
+        "Υπομονή, Ενσυναίσθηση και Συμπόνια"
       ]
     },
     "sacredCompanion": {
-      "title": "Sacred Companion",
+      "title": "Ιερός Σύντροφος",
       "paragraphs": [
-        "This manual is a sacred companion for those who have been initiated into the path of Rose Meditation.",
-        "These teachings are part of a living energetic lineage. They invite inner stillness, gentle discipline, and deep self-responsibility. ROSES OS is not a system to be imposed or taught casually — it is an energetic operating system revealed through direct practice and transmission."
+        "Αυτό το εγχειρίδιο είναι ένας ιερός σύντροφος για όσους έχουν μυηθεί στο μονοπάτι του Διαλογισμού του Τριαντάφυλλου.",
+        "Αυτές οι διδασκαλίες αποτελούν μέρος μιας ζωντανής ενεργειακής καταγωγής. Προσκαλούν στην εσωτερική ηρεμία, την ήπια πειθαρχία και τη βαθιά αυτοευθύνη. Το ROSES OS δεν είναι ένα σύστημα που επιβάλλεται ή διδάσκεται επιπόλαια — είναι ένα ενεργειακό λειτουργικό σύστημα που αποκαλύπτεται μέσω της άμεσης πρακτικής και της μετάδοσης."
       ],
-      "guidelinesTitle": "To honor the integrity of this work:",
+      "guidelinesTitle": "Για να τιμήσουμε την ακεραιότητα αυτού του έργου:",
       "guidelinesItems": [
-        "Please do not share this material with others who have not received the transmission.",
-        "This manual is for personal use only and cannot be used to teach or guide others.",
-        "You are welcome to support children under your care with these tools."
+        "Παρακαλούμε μη μοιράζεστε αυτό το υλικό με άλλους που δεν έχουν λάβει τη μετάδοση.",
+        "Αυτό το εγχειρίδιο είναι μόνο για προσωπική χρήση και δεν μπορεί να χρησιμοποιηθεί για να διδάξετε ή να καθοδηγήσετε άλλους.",
+        "Μπορείτε να στηρίξετε τα παιδιά υπό τη φροντίδα σας με αυτά τα εργαλεία."
       ],
-      "closing": "Let each page be a reminder of the sacred space within you."
+      "closing": "Ας είναι κάθε σελίδα μια υπενθύμιση του ιερού χώρου μέσα σας."
     },
     "history": {
-      "title": "History & Lineage",
-      "text": "Aura Reading emerged in the 1960s, in California, channeled by a North American called Lewis S. Bostwick. Founder of the Berkeley Psychic Institute and the Church of the Divine Man, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.",
+      "title": "Ιστορία και Καταγωγή",
+      "text": "Η Ανάγνωση Αύρας εμφανίστηκε τη δεκαετία του 1960, στην Καλιφόρνια, διοχετευμένη από έναν Βορειοαμερικανό ονόματι Lewis S. Bostwick. Ιδρυτής του Berkeley Psychic Institute και της Church of the Divine Man, διοχέτευσε και συστηματοποίησε τις τεχνικές και τα εργαλεία που στάλθηκαν από τους αγγέλους, για να βοηθήσουν στη διαδικασία εξέλιξης της ανθρωπότητας.",
       "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → ROSES OS"
     }
   },
   "levels": {
     "1": {
-      "title": "Level 1: Foundation",
-      "subtitle": "Core Practices",
-      "description": "The essential practices that form the foundation of all ROSES OS work. Breath, body, heart, and the Rose Meditation."
+      "title": "Επίπεδο 1: Θεμέλιο",
+      "subtitle": "Θεμελιώδεις Πρακτικές",
+      "description": "Οι βασικές πρακτικές που αποτελούν τη βάση όλης της εργασίας του ROSES OS. Αναπνοή, σώμα, καρδιά και ο Διαλογισμός του Τριαντάφυλλου."
     },
     "2": {
-      "title": "Level 2: Deepening",
-      "subtitle": "Energetic & Relational",
-      "description": "Advanced practices for subtle body awareness, emotional alchemy, and relational coherence."
+      "title": "Επίπεδο 2: Εμβάθυνση",
+      "subtitle": "Ενεργειακό και Σχεσιακό",
+      "description": "Προχωρημένες πρακτικές για την επίγνωση του λεπτού σώματος, την συναισθηματική αλχημεία και τη σχεσιακή συνοχή."
     },
     "3": {
-      "title": "Level 3: Teaching",
-      "subtitle": "Transmission & Facilitation",
-      "description": "Practices and principles for holding space, transmitting the work, and serving as a guardian of the lineage."
+      "title": "Επίπεδο 3: Διδασκαλία",
+      "subtitle": "Μετάδοση και Διευκόλυνση",
+      "description": "Πρακτικές και αρχές για τη διατήρηση του χώρου, τη μετάδοση της εργασίας και την υπηρεσία ως φύλακας της καταγωγής."
     }
   },
   "slides": {
     "l1-the-rose": {
-      "concept": "The Rose",
-      "teachingText": "The Rose is the foundational symbol and tool of this practice — a living energetic instrument used throughout all levels of the work."
+      "concept": "Το Τριαντάφυλλο",
+      "teachingText": "Το Τριαντάφυλλο είναι το θεμελιώδες σύμβολο και εργαλείο αυτής της πρακτικής — ένα ζωντανό ενεργειακό όργανο που χρησιμοποιείται σε όλα τα επίπεδα της εργασίας."
     },
     "l1-posture": {
-      "concept": "Meditation Posture",
-      "teachingText": "Proper meditation posture is seated upright in a chair. Feet are flat on the floor, hands resting gently on the thighs or knees, spine upright, eyes closed. The body is relaxed yet alert — grounded and receptive."
+      "concept": "Στάση Διαλογισμού",
+      "teachingText": "Η σωστή στάση διαλογισμού είναι καθισμένος όρθια σε μια καρέκλα. Τα πόδια είναι επίπεδα στο πάτωμα, τα χέρια ακουμπούν ελαφρά στους μηρούς ή τα γόνατα, η σπονδυλική στήλη ευθεία, τα μάτια κλειστά. Το σώμα είναι χαλαρό αλλά σε εγρήγορση — γειωμένο και δεκτικό."
     },
     "l1-grounding-cord": {
-      "concept": "Grounding Cord",
-      "teachingText": "The grounding cord is an energetic connection that extends from the base of the spine (first chakra) downward into the center of the Earth. It anchors your energy body to the planet, providing stability, safety, and a channel for releasing unwanted energy."
+      "concept": "Σχοινί Γείωσης",
+      "teachingText": "Το σχοινί γείωσης είναι μια ενεργειακή σύνδεση που εκτείνεται από τη βάση της σπονδυλικής στήλης (πρώτο τσάκρα) προς τα κάτω μέχρι το κέντρο της Γης. Αγκυροβολεί το ενεργειακό σας σώμα στον πλανήτη, παρέχοντας σταθερότητα, ασφάλεια και ένα κανάλι για την απελευθέρωση ανεπιθύμητης ενέργειας."
     },
     "l1-golden-sun": {
-      "concept": "Golden Sun",
-      "teachingText": "The Golden Sun is a tool for replenishing and restoring your own energy. Visualize a radiant golden sun above your head. It calls back your own life-force energy from wherever you may have left it — in people, places, situations, or time. It fills you with your own highest vibration."
+      "concept": "Χρυσός Ήλιος",
+      "teachingText": "Ο Χρυσός Ήλιος είναι ένα εργαλείο για την αναπλήρωση και αποκατάσταση της δικής σας ενέργειας. Οραματιστείτε έναν λαμπερό χρυσό ήλιο πάνω από το κεφάλι σας. Καλεί πίσω τη δική σας ζωτική ενέργεια από οπουδήποτε μπορεί να την αφήσατε — σε ανθρώπους, τόπους, καταστάσεις ή στον χρόνο. Σας γεμίζει με τη δική σας υψηλότερη δόνηση."
     },
     "l1-aura-exercise": {
-      "concept": "An Exercise to Feel Your Aura",
-      "teachingText": "The aura is the energetic field that surrounds your physical body. This exercise helps you become aware of its presence, its edges, and its quality. The aura consists of multiple layers radiating outward from the body."
+      "concept": "Μια Άσκηση για να Αισθανθείτε την Αύρα σας",
+      "teachingText": "Η αύρα είναι το ενεργειακό πεδίο που περιβάλλει το φυσικό σας σώμα. Αυτή η άσκηση σας βοηθά να αποκτήσετε επίγνωση της παρουσίας, των ορίων και της ποιότητάς της. Η αύρα αποτελείται από πολλαπλά στρώματα που ακτινοβολούν προς τα έξω από το σώμα."
     },
     "l1-grounding-expansion": {
-      "concept": "Expansion of Grounding Cord",
-      "teachingText": "Once you are aware of your aura, the grounding cord practice deepens. You ground not only the physical body but also the aura itself — allowing the entire energy field to anchor into the Earth."
+      "concept": "Επέκταση του Σχοινιού Γείωσης",
+      "teachingText": "Μόλις αποκτήσετε επίγνωση της αύρας σας, η πρακτική γείωσης βαθαίνει. Γειώνετε όχι μόνο το φυσικό σώμα αλλά και την ίδια την αύρα — επιτρέποντας σε ολόκληρο το ενεργειακό πεδίο να αγκυροβολήσει στη Γη."
     },
     "l1-full-setup": {
-      "concept": "Full Meditation Setup",
-      "teachingText": "The complete foundational setup combines posture, aura, and expanded grounding cord: the person is seated in proper posture, enclosed within their aura, with the grounding cord descending into the earth."
+      "concept": "Πλήρης Ρύθμιση Διαλογισμού",
+      "teachingText": "Η πλήρης θεμελιώδης ρύθμιση συνδυάζει στάση, αύρα και εκτεταμένο σχοινί γείωσης: το άτομο κάθεται σε σωστή στάση, περικλεισμένο μέσα στην αύρα του, με το σχοινί γείωσης να κατεβαίνει στη γη."
     },
     "l1-golden-sun-fills": {
-      "concept": "Golden Sun Fills You",
-      "teachingText": "The Golden Sun above the crown pours golden light downward, filling the entire aura and body with your own highest vibration. This completes the full energetic architecture: posture, aura, grounding cord, and golden sun — all active together."
+      "concept": "Ο Χρυσός Ήλιος σας Γεμίζει",
+      "teachingText": "Ο Χρυσός Ήλιος πάνω από την κορυφή χύνει χρυσό φως προς τα κάτω, γεμίζοντας ολόκληρη την αύρα και το σώμα με τη δική σας υψηλότερη δόνηση. Αυτό ολοκληρώνει την πλήρη ενεργειακή αρχιτεκτονική: στάση, αύρα, σχοινί γείωσης και χρυσός ήλιος — όλα ενεργά μαζί."
     },
     "l1-earth-circuit": {
-      "concept": "Circuit of the Energy of the Earth",
-      "teachingText": "The Earth circuit is an energetic pathway that draws the energy of the Earth upward through the feet, rising through the legs and into the body. This circuit connects you to the grounding, nourishing, stabilizing force of the planet."
+      "concept": "Κύκλωμα της Ενέργειας της Γης",
+      "teachingText": "Το κύκλωμα της Γης είναι ένα ενεργειακό μονοπάτι που έλκει την ενέργεια της Γης προς τα πάνω μέσω των ποδιών, ανεβαίνοντας μέσα από τα πόδια και εισερχόμενο στο σώμα. Αυτό το κύκλωμα σας συνδέει με τη γειωτική, θρεπτική, σταθεροποιητική δύναμη του πλανήτη."
     },
     "l1-cosmos-circuit": {
-      "concept": "Circuit of the Energy of the Cosmos",
-      "teachingText": "The Cosmic circuit is an energetic pathway that draws cosmic energy downward through the crown of the head (7th chakra) and into the body. This circuit connects you to the higher frequencies of universal consciousness, inspiration, and spiritual guidance."
+      "concept": "Κύκλωμα της Ενέργειας του Κόσμου",
+      "teachingText": "Το Κοσμικό κύκλωμα είναι ένα ενεργειακό μονοπάτι που έλκει την κοσμική ενέργεια προς τα κάτω μέσω της κορυφής του κεφαλιού (7ο τσάκρα) και μέσα στο σώμα. Αυτό το κύκλωμα σας συνδέει με τις υψηλότερες συχνότητες της παγκόσμιας συνείδησης, της έμπνευσης και της πνευματικής καθοδήγησης."
     },
     "l1-combined-circuit": {
-      "concept": "Circuit of Energy of Cosmos and Earth",
-      "teachingText": "When both circuits are activated simultaneously, the energies of the Earth and Cosmos flow together through the body. Earth energy rises from below; Cosmic energy descends from above. They meet and blend within the body, creating a unified field of balanced, integrated energy."
+      "concept": "Κύκλωμα Ενέργειας του Κόσμου και της Γης",
+      "teachingText": "Όταν και τα δύο κυκλώματα ενεργοποιούνται ταυτόχρονα, οι ενέργειες της Γης και του Κόσμου ρέουν μαζί μέσα στο σώμα. Η ενέργεια της Γης ανεβαίνει από κάτω· η Κοσμική ενέργεια κατεβαίνει από πάνω. Συναντώνται και αναμειγνύονται μέσα στο σώμα, δημιουργώντας ένα ενοποιημένο πεδίο ισορροπημένης, ολοκληρωμένης ενέργειας."
     },
     "l1-rose-tool": {
-      "concept": "The Rose (as Energetic Tool)",
-      "teachingText": "The Rose is used as a living energetic instrument throughout the practice. It has roots (connection to source), a stem (channel of energy), and a bloom (the active, radiant tool). The Rose can be placed, moved, opened, closed, and released according to the needs of the meditation."
+      "concept": "Το Τριαντάφυλλο (ως Ενεργειακό Εργαλείο)",
+      "teachingText": "Το Τριαντάφυλλο χρησιμοποιείται ως ζωντανό ενεργειακό όργανο σε όλη την πρακτική. Έχει ρίζες (σύνδεση με την πηγή), ένα στέλεχος (κανάλι ενέργειας) και ένα άνθος (το ενεργό, ακτινοβόλο εργαλείο). Το Τριαντάφυλλο μπορεί να τοποθετηθεί, να μετακινηθεί, να ανοίξει, να κλείσει και να απελευθερωθεί ανάλογα με τις ανάγκες του διαλογισμού."
     },
     "l1-four-roses": {
-      "concept": "Roses of Protection, Observation and Separation",
-      "teachingText": "Roses are placed at the edges of the aura to serve as energetic sentinels. They perform three functions:\n\n1. Protection — They define and guard the boundary of your aura\n2. Observation — They help you notice what energies are approaching or interacting with your field\n3. Separation — They create healthy energetic distinction between your energy and the energy of others"
+      "concept": "Τριαντάφυλλα Προστασίας, Παρατήρησης και Διαχωρισμού",
+      "teachingText": "Τα Τριαντάφυλλα τοποθετούνται στα άκρα της αύρας για να λειτουργούν ως ενεργειακοί φρουροί. Εκτελούν τρεις λειτουργίες:\n\n1. Προστασία — Ορίζουν και φυλάσσουν τα όρια της αύρας σας\n2. Παρατήρηση — Σας βοηθούν να παρατηρήσετε ποιες ενέργειες πλησιάζουν ή αλληλεπιδρούν με το πεδίο σας\n3. Διαχωρισμός — Δημιουργούν υγιή ενεργειακή διάκριση μεταξύ της δικής σας ενέργειας και της ενέργειας των άλλων"
     },
     "l1-cleansing-rose": {
-      "concept": "Cleansing Rose",
-      "teachingText": "The Cleansing Rose is placed outside of the aura. It is used to absorb and transmute foreign or stagnant energy from within your field. Energy that does not belong to you — from other people, environments, or experiences — is drawn out of the aura and into the Cleansing Rose, where it is neutralized."
+      "concept": "Τριαντάφυλλο Καθαρισμού",
+      "teachingText": "Το Τριαντάφυλλο Καθαρισμού τοποθετείται έξω από την αύρα. Χρησιμοποιείται για να απορροφήσει και να μετατρέψει ξένη ή στάσιμη ενέργεια μέσα από το πεδίο σας. Ενέργεια που δεν σας ανήκει — από άλλους ανθρώπους, περιβάλλοντα ή εμπειρίες — έλκεται έξω από την αύρα και μέσα στο Τριαντάφυλλο Καθαρισμού, όπου εξουδετερώνεται."
     },
     "l1-energy-recovery": {
-      "concept": "Energy Recovery of Each Chakra",
-      "teachingText": "After cleansing, the Rose is used to recover your own energy that has been left in or taken by others. The Rose is sent out as an instrument to gather and return your own life-force energy to each chakra, restoring fullness and sovereignty to each energy center."
+      "concept": "Ενεργειακή Ανάκτηση Κάθε Τσάκρα",
+      "teachingText": "Μετά τον καθαρισμό, το Τριαντάφυλλο χρησιμοποιείται για να ανακτήσει τη δική σας ενέργεια που αφέθηκε ή πάρθηκε από άλλους. Το Τριαντάφυλλο στέλνεται ως όργανο για να συγκεντρώσει και να επιστρέψει τη δική σας ζωτική ενέργεια σε κάθε τσάκρα, αποκαθιστώντας πληρότητα και κυριαρχία σε κάθε ενεργειακό κέντρο."
     },
     "l1-discharge": {
-      "concept": "Discharge Excess Energy",
-      "teachingText": "After deep meditation or energy work, excess energy may accumulate in the body. To discharge it, lean forward from the seated position with hands reaching toward the ground. Allow the excess energy to flow out through the hands and into the earth, returning the body to a calm, balanced state."
+      "concept": "Εκφόρτιση Πλεονάζουσας Ενέργειας",
+      "teachingText": "Μετά από βαθύ διαλογισμό ή ενεργειακή εργασία, πλεονάζουσα ενέργεια μπορεί να συσσωρευτεί στο σώμα. Για να την εκφορτίσετε, σκύψτε μπροστά από την καθιστή θέση με τα χέρια να φτάνουν προς το έδαφος. Αφήστε την πλεονάζουσα ενέργεια να ρεύσει μέσα από τα χέρια και μέσα στη γη, επαναφέροντας το σώμα σε μια ήρεμη, ισορροπημένη κατάσταση."
     },
     "l2-sacred-space": {
-      "concept": "Let’s Create Your Sacred Space",
-      "teachingText": "Level 2 begins with creating your own sacred space — an internal energetic environment that serves as your meditation home. This is the space from which all deeper work is conducted."
+      "concept": "Ας Δημιουργήσουμε τον Ιερό σας Χώρο",
+      "teachingText": "Το Επίπεδο 2 ξεκινά με τη δημιουργία του δικού σας ιερού χώρου — ενός εσωτερικού ενεργειακού περιβάλλοντος που χρησιμεύει ως το σπίτι διαλογισμού σας. Αυτός είναι ο χώρος από τον οποίο διεξάγεται κάθε βαθύτερη εργασία."
     },
     "l2-6th-7th-chakras": {
-      "concept": "The 6th and 7th Chakras (Sacred Space)",
-      "teachingText": "Understanding the locations and roles of the upper chakras is essential for Level 2 work:\n\n• 6th Chakra (Third Eye) — Located at the center of the forehead, between and slightly above the eyebrows\n• 7th Chakra (Crown) — Located at the top of the head"
+      "concept": "Το 6ο και 7ο Τσάκρα (Ιερός Χώρος)",
+      "teachingText": "Η κατανόηση των θέσεων και ρόλων των ανώτερων τσάκρα είναι απαραίτητη για την εργασία του Επιπέδου 2:\n\n• 6ο Τσάκρα (Τρίτο Μάτι) — Βρίσκεται στο κέντρο του μετώπου, ανάμεσα και λίγο πάνω από τα φρύδια\n• 7ο Τσάκρα (Στέμμα) — Βρίσκεται στην κορυφή του κεφαλιού"
     },
     "l2-physical-space": {
-      "concept": "Let’s Prepare Your Physical Space",
-      "teachingText": "Before meditation, prepare your physical environment to support the energetic work. The external space should mirror the internal intention: clean, clear, quiet, and intentionally held."
+      "concept": "Ας Προετοιμάσουμε τον Φυσικό σας Χώρο",
+      "teachingText": "Πριν από τον διαλογισμό, προετοιμάστε τον φυσικό σας χώρο για να στηρίξει την ενεργειακή εργασία. Ο εξωτερικός χώρος πρέπει να αντικατοπτρίζει την εσωτερική πρόθεση: καθαρός, ξεκάθαρος, ήσυχος και σκόπιμα διατηρημένος."
     },
     "l2-protection-space": {
-      "concept": "Protection of the Space",
-      "teachingText": "The physical meditation space is protected by creating an energetic grid using roses. Golden roses are placed at the four corners (and above/below) of the space, connected by lines of golden energy forming a sacred geometric structure — a container for the work."
+      "concept": "Προστασία του Χώρου",
+      "teachingText": "Ο φυσικός χώρος διαλογισμού προστατεύεται δημιουργώντας ένα ενεργειακό πλέγμα χρησιμοποιώντας τριαντάφυλλα. Χρυσά τριαντάφυλλα τοποθετούνται στις τέσσερις γωνίες (και πάνω/κάτω) του χώρου, συνδεδεμένα με γραμμές χρυσής ενέργειας σχηματίζοντας μια ιερή γεωμετρική δομή — ένα δοχείο για την εργασία."
     },
     "l2-cleansing-space": {
-      "concept": "Cleansing of the Space",
-      "teachingText": "Once the space is protected, it is cleansed. A large Cleansing Rose is placed above the grid, and golden energy pours downward through the entire structure, clearing all foreign, stagnant, or disruptive energies from the space."
+      "concept": "Καθαρισμός του Χώρου",
+      "teachingText": "Μόλις ο χώρος προστατευθεί, καθαρίζεται. Ένα μεγάλο Τριαντάφυλλο Καθαρισμού τοποθετείται πάνω από το πλέγμα, και χρυσή ενέργεια χύνεται προς τα κάτω μέσα από ολόκληρη τη δομή, καθαρίζοντας κάθε ξένη, στάσιμη ή διαταρακτική ενέργεια από τον χώρο."
     },
     "l2-owning-space": {
-      "concept": "Owning Your Space",
-      "teachingText": "After protection and cleansing, you claim ownership of the space. This is an act of energetic sovereignty — declaring the space as yours, filling it with your own energy and intention. The space becomes an extension of your aura and your practice."
+      "concept": "Κατοχή του Χώρου σας",
+      "teachingText": "Μετά την προστασία και τον καθαρισμό, διεκδικείτε την κυριότητα του χώρου. Αυτή είναι μια πράξη ενεργειακής κυριαρχίας — δηλώνοντας τον χώρο ως δικό σας, γεμίζοντάς τον με τη δική σας ενέργεια και πρόθεση. Ο χώρος γίνεται μια επέκταση της αύρας σας και της πρακτικής σας."
     },
     "l2-chakras-intro": {
-      "concept": "Let’s Talk About Chakras",
-      "teachingText": "The chakra system is the energetic anatomy of the human body. There are seven primary chakras, each governing specific aspects of physical, emotional, mental, and spiritual life."
+      "concept": "Ας Μιλήσουμε για τα Τσάκρα",
+      "teachingText": "Το σύστημα τσάκρα είναι η ενεργειακή ανατομία του ανθρώπινου σώματος. Υπάρχουν επτά κύρια τσάκρα, καθένα από τα οποία διέπει συγκεκριμένες πτυχές της σωματικής, συναισθηματικής, νοητικής και πνευματικής ζωής."
     },
     "l2-seven-chakras": {
-      "concept": "The Seven Chakras",
-      "teachingText": "The seven primary chakras, from crown to root:\n\n7. Crown — Top of head\n6. Third Eye — Center of forehead\n5. Throat — Throat\n4. Heart — Center of chest\n3. Solar Plexus — Upper abdomen\n2. Sacral — Lower abdomen\n1. Root — Base of spine"
+      "concept": "Τα Επτά Τσάκρα",
+      "teachingText": "Τα επτά κύρια τσάκρα, από το στέμμα ως τη ρίζα:\n\n7. Στέμμα — Κορυφή του κεφαλιού\n6. Τρίτο Μάτι — Κέντρο του μετώπου\n5. Λαιμός — Λαιμός\n4. Καρδιά — Κέντρο του στήθους\n3. Ηλιακό Πλέγμα — Άνω κοιλία\n2. Ιερό — Κάτω κοιλία\n1. Ρίζα — Βάση της σπονδυλικής στήλης"
     },
     "l2-cleansing-aura-layers": {
-      "concept": "Cleansing of Each Aura Layer",
-      "teachingText": "The aura is composed of seven layers, each corresponding to a chakra. In Level 2, each layer is individually cleansed from the outermost to the innermost:\n\n7. 7th Aura layer\n6. 6th Aura layer\n5. 5th Aura layer\n4. 4th Aura layer\n3. 3rd Aura layer\n2. 2nd Aura layer\n1. 1st Aura layer"
+      "concept": "Καθαρισμός Κάθε Στρώματος της Αύρας",
+      "teachingText": "Η αύρα αποτελείται από επτά στρώματα, καθένα αντιστοιχεί σε ένα τσάκρα. Στο Επίπεδο 2, κάθε στρώμα καθαρίζεται ξεχωριστά από το εξωτερικότερο στο εσωτερικότερο:\n\n7. 7ο στρώμα Αύρας\n6. 6ο στρώμα Αύρας\n5. 5ο στρώμα Αύρας\n4. 4ο στρώμα Αύρας\n3. 3ο στρώμα Αύρας\n2. 2ο στρώμα Αύρας\n1. 1ο στρώμα Αύρας"
     },
     "l2-cleansing-each-chakra": {
-      "concept": "Cleansing of Each Chakra",
-      "teachingText": "Each individual chakra is cleansed using roses. The roses address two dimensions:\n\n• Dynamics of the Past — Energetic patterns, imprints, and blockages carried from past experiences\n• Dynamics of the Present — Current energetic influences, relationships, and situations affecting the chakra"
+      "concept": "Καθαρισμός Κάθε Τσάκρα",
+      "teachingText": "Κάθε μεμονωμένο τσάκρα καθαρίζεται χρησιμοποιώντας τριαντάφυλλα. Τα τριαντάφυλλα αντιμετωπίζουν δύο διαστάσεις:\n\n• Δυναμικές του Παρελθόντος — Ενεργειακά μοτίβα, αποτυπώματα και μπλοκαρίσματα που κουβαλιούνται από παρελθοντικές εμπειρίες\n• Δυναμικές του Παρόντος — Τρέχουσες ενεργειακές επιρροές, σχέσεις και καταστάσεις που επηρεάζουν το τσάκρα"
     },
     "l2-energy-recovery": {
-      "concept": "Energy Recovery of Each Chakra (Level 2)",
-      "teachingText": "After cleansing, the energy recovery process is repeated at a deeper level. The Rose is sent out to gather and return your own energy to each individual chakra, restoring sovereignty, vitality, and wholeness to each energy center."
+      "concept": "Ενεργειακή Ανάκτηση Κάθε Τσάκρα (Επίπεδο 2)",
+      "teachingText": "Μετά τον καθαρισμό, η διαδικασία ενεργειακής ανάκτησης επαναλαμβάνεται σε βαθύτερο επίπεδο. Το Τριαντάφυλλο στέλνεται για να συγκεντρώσει και να επιστρέψει τη δική σας ενέργεια σε κάθε μεμονωμένο τσάκρα, αποκαθιστώντας κυριαρχία, ζωτικότητα και ολότητα σε κάθε ενεργειακό κέντρο."
     },
     "l2-golden-sticky-1": {
-      "concept": "Golden Sticky Roses — Phase 1 (Chakra Placement)",
-      "teachingText": "Golden sticky roses are placed on each of the seven chakras, drawing out foreign energy lodged in the energy centers."
+      "concept": "Χρυσά Κολλώδη Τριαντάφυλλα — Φάση 1 (Τοποθέτηση στα Τσάκρα)",
+      "teachingText": "Χρυσά κολλώδη τριαντάφυλλα τοποθετούνται σε καθένα από τα επτά τσάκρα, εξάγοντας ξένη ενέργεια που έχει εγκατασταθεί στα ενεργειακά κέντρα."
     },
     "l2-golden-sticky-2": {
-      "concept": "Golden Sticky Roses — Phase 2 (Body Placement)",
-      "teachingText": "Golden sticky roses are placed at the joints and extremities of the body — shoulders, elbows, wrists, hands, hips, knees, ankles, feet — drawing out foreign energy stored in the physical body."
+      "concept": "Χρυσά Κολλώδη Τριαντάφυλλα — Φάση 2 (Τοποθέτηση στο Σώμα)",
+      "teachingText": "Χρυσά κολλώδη τριαντάφυλλα τοποθετούνται στις αρθρώσεις και τα άκρα του σώματος — ώμους, αγκώνες, καρπούς, χέρια, γοφούς, γόνατα, αστραγάλους, πόδια — εξάγοντας ξένη ενέργεια αποθηκευμένη στο φυσικό σώμα."
     },
     "l2-golden-sticky-3": {
-      "concept": "Golden Sticky Roses — Phase 3 (Full Body Coverage)",
-      "teachingText": "Golden sticky roses are placed throughout the entire body — covering the torso, limbs, and all remaining areas — for a thorough, complete energetic cleansing."
+      "concept": "Χρυσά Κολλώδη Τριαντάφυλλα — Φάση 3 (Πλήρης Κάλυψη Σώματος)",
+      "teachingText": "Χρυσά κολλώδη τριαντάφυλλα τοποθετούνται σε ολόκληρο το σώμα — καλύπτοντας τον κορμό, τα άκρα και όλες τις υπόλοιπες περιοχές — για έναν ολοκληρωμένο, πλήρη ενεργειακό καθαρισμό."
     },
     "l2-golden-sticky-4": {
-      "concept": "Golden Sticky Roses — Phase 4 (Integration)",
-      "teachingText": "After the golden sticky roses have done their work, a large Golden Rose appears above the head. All foreign energy gathered by the sticky roses is released, and the entire body is bathed in golden light — restoring, sealing, and integrating the energy body."
+      "concept": "Χρυσά Κολλώδη Τριαντάφυλλα — Φάση 4 (Ολοκλήρωση)",
+      "teachingText": "Αφού τα χρυσά κολλώδη τριαντάφυλλα ολοκληρώσουν το έργο τους, ένα μεγάλο Χρυσό Τριαντάφυλλο εμφανίζεται πάνω από το κεφάλι. Κάθε ξένη ενέργεια που συγκεντρώθηκε από τα κολλώδη τριαντάφυλλα απελευθερώνεται, και ολόκληρο το σώμα λούζεται σε χρυσό φως — αποκαθιστώντας, σφραγίζοντας και ολοκληρώνοντας το ενεργειακό σώμα."
     },
     "l3-analyzer": {
-      "concept": "The Analyzer",
-      "teachingText": "The Analyzer is an advanced tool introduced in Level 3. It is an energetic point located at the back of the head, at the base of the skull (the occipital ridge / brainstem area). The Analyzer is used for deeper perception, reading, and discernment of energy — a tool for precise energetic analysis."
+      "concept": "Ο Αναλυτής",
+      "teachingText": "Ο Αναλυτής είναι ένα προχωρημένο εργαλείο που εισάγεται στο Επίπεδο 3. Είναι ένα ενεργειακό σημείο που βρίσκεται στο πίσω μέρος του κεφαλιού, στη βάση του κρανίου (η ινιακή ακρολοφία / περιοχή του εγκεφαλικού στελέχους). Ο Αναλυτής χρησιμοποιείται για βαθύτερη αντίληψη, ανάγνωση και διάκριση ενέργειας — ένα εργαλείο για ακριβή ενεργειακή ανάλυση."
     }
   },
   "chakras": {
     "l2-chakra-root": {
-      "concept": "Root Chakra",
-      "teachingText": "Muladhara — Grounding & Safety",
-      "focus": "Stability — Safety — Embodiment",
-      "energy": "Masculine — Survival / Foundation",
-      "bodyLocation": "Base of spine, Legs, Feet",
+      "concept": "Τσάκρα της Ρίζας",
+      "teachingText": "Muladhara — Γείωση και Ασφάλεια",
+      "focus": "Σταθερότητα — Ασφάλεια — Ενσωμάτωση",
+      "energy": "Αρσενική — Επιβίωση / Θεμέλιο",
+      "bodyLocation": "Βάση της σπονδυλικής στήλης, Πόδια, Πέλματα",
       "balanced": [
-        "Grounded presence",
-        "Physical vitality",
-        "Trust in life",
-        "Feeling safe in the body"
+        "Γειωμένη παρουσία",
+        "Σωματική ζωτικότητα",
+        "Εμπιστοσύνη στη ζωή",
+        "Αίσθηση ασφάλειας στο σώμα"
       ],
       "unbalanced": [
-        "Fear and insecurity",
-        "Survival anxiety",
-        "Disconnection from body",
-        "Scarcity mindset"
+        "Φόβος και ανασφάλεια",
+        "Άγχος επιβίωσης",
+        "Αποσύνδεση από το σώμα",
+        "Νοοτροπία έλλειψης"
       ],
-      "blockages": "Fear — Insecurity — Survival Trauma"
+      "blockages": "Φόβος — Ανασφάλεια — Τραύμα Επιβίωσης"
     },
     "l2-chakra-sacral": {
-      "concept": "Sacral Chakra",
-      "teachingText": "Svadhisthana — Emotion & Creativity",
-      "focus": "Emotions — Creativity — Pleasure",
-      "energy": "Feminine — Flow & Flexibility",
-      "bodyLocation": "Lower abdomen, Sexual Organs",
+      "concept": "Ιερό Τσάκρα",
+      "teachingText": "Svadhisthana — Συναίσθημα και Δημιουργικότητα",
+      "focus": "Συναισθήματα — Δημιουργικότητα — Ηδονή",
+      "energy": "Θηλυκή — Ροή και Ευελιξία",
+      "bodyLocation": "Κάτω κοιλία, Γεννητικά Όργανα",
       "balanced": [
-        "Emotional well-being",
-        "Sensuality and intimacy",
-        "Passion and pleasure",
-        "Adaptability"
+        "Συναισθηματική ευημερία",
+        "Αισθησιασμός και οικειότητα",
+        "Πάθος και ηδονή",
+        "Προσαρμοστικότητα"
       ],
       "unbalanced": [
-        "Depression and numbness",
-        "Sexual dysfunction",
-        "Emotional instability",
-        "Fear of change"
+        "Κατάθλιψη και μούδιασμα",
+        "Σεξουαλική δυσλειτουργία",
+        "Συναισθηματική αστάθεια",
+        "Φόβος αλλαγής"
       ],
-      "blockages": "Shame — Emotional Repression — Guilt"
+      "blockages": "Ντροπή — Συναισθηματική Καταστολή — Ενοχή"
     },
     "l2-chakra-solar-plexus": {
-      "concept": "Solar Plexus Chakra",
-      "teachingText": "Manipura — Willpower & Confidence",
-      "focus": "Personal Power — Self-Esteem — Drive",
-      "energy": "Masculine — Power & Transformation",
-      "bodyLocation": "Upper abdomen, Diaphragm",
+      "concept": "Τσάκρα του Ηλιακού Πλέγματος",
+      "teachingText": "Manipura — Δύναμη Θέλησης και Αυτοπεποίθηση",
+      "focus": "Προσωπική Δύναμη — Αυτοεκτίμηση — Κίνητρο",
+      "energy": "Αρσενική — Δύναμη και Μεταμόρφωση",
+      "bodyLocation": "Άνω κοιλία, Διάφραγμα",
       "balanced": [
-        "Confidence and motivation",
-        "Responsible and disciplined",
-        "Healthy sense of self",
-        "Autonomy"
+        "Αυτοπεποίθηση και κίνητρο",
+        "Υπεύθυνος και πειθαρχημένος",
+        "Υγιής αίσθηση εαυτού",
+        "Αυτονομία"
       ],
       "unbalanced": [
-        "Low self-esteem",
-        "Aggression or controlling",
-        "Stubborn and domineering",
-        "Lack of direction or purpose"
+        "Χαμηλή αυτοεκτίμηση",
+        "Επιθετικότητα ή ελεγκτικότητα",
+        "Πεισματάρης και κυριαρχικός",
+        "Έλλειψη κατεύθυνσης ή σκοπού"
       ],
-      "blockages": "Self-Doubt — Insecurity — Fear of Rejection"
+      "blockages": "Αμφιβολία για τον Εαυτό — Ανασφάλεια — Φόβος Απόρριψης"
     },
     "l2-chakra-heart": {
-      "concept": "Heart Chakra",
-      "teachingText": "Anahata — Love & Integration",
-      "focus": "Love — Compassion — Connection",
-      "energy": "Bridge between physical & spiritual",
-      "bodyLocation": "Center of chest, Heart, Lungs",
+      "concept": "Τσάκρα της Καρδιάς",
+      "teachingText": "Anahata — Αγάπη και Ολοκλήρωση",
+      "focus": "Αγάπη — Συμπόνια — Σύνδεση",
+      "energy": "Γέφυρα μεταξύ φυσικού και πνευματικού",
+      "bodyLocation": "Κέντρο του στήθους, Καρδιά, Πνεύμονες",
       "balanced": [
-        "Compassion and empathy",
-        "Emotional openness",
-        "Forgiveness",
-        "Healthy intimacy and self-love"
+        "Συμπόνια και ενσυναίσθηση",
+        "Συναισθηματική ανοιχτότητα",
+        "Συγχώρεση",
+        "Υγιής οικειότητα και αυτοαγάπη"
       ],
       "unbalanced": [
-        "Emotional withdrawal or over-giving",
-        "Fear of intimacy",
-        "Cold or detachment",
-        "Difficulty forgiving"
+        "Συναισθηματική απόσυρση ή υπερβολική προσφορά",
+        "Φόβος οικειότητας",
+        "Ψυχρότητα ή αποστασιοποίηση",
+        "Δυσκολία στη συγχώρεση"
       ],
-      "blockages": "Grief — Betrayal — Heartbreak",
-      "extraContent": "Human Love & Spiritual Love:\n\nHuman Love — Statement: I LOVE — Empathy, compassion, forgiveness, healthy relationships, romantic and familial love.\n\nSpiritual Love — Statement: I AM LOVE — Unconditional compassion, interconnectedness, divine and universal love, oneness."
+      "blockages": "Θλίψη — Προδοσία — Ραγισμένη Καρδιά",
+      "extraContent": "Ανθρώπινη Αγάπη και Πνευματική Αγάπη:\n\nΑνθρώπινη Αγάπη — Δήλωση: ΑΓΑΠΩ — Ενσυναίσθηση, συμπόνια, συγχώρεση, υγιείς σχέσεις, ρομαντική και οικογενειακή αγάπη.\n\nΠνευματική Αγάπη — Δήλωση: ΕΙΜΑΙ ΑΓΑΠΗ — Ανεπιφύλακτη συμπόνια, αλληλοσύνδεση, θεϊκή και παγκόσμια αγάπη, ενότητα."
     },
     "l2-chakra-throat": {
-      "concept": "Throat Chakra",
-      "teachingText": "Vishuddha — Communication & Expression",
-      "focus": "Communication — Truth — Authenticity",
-      "energy": "Learning to align will with divine truth",
-      "bodyLocation": "Throat, Neck, Jaw, Mouth",
+      "concept": "Τσάκρα του Λαιμού",
+      "teachingText": "Vishuddha — Επικοινωνία και Έκφραση",
+      "focus": "Επικοινωνία — Αλήθεια — Αυθεντικότητα",
+      "energy": "Μαθαίνοντας να ευθυγραμμίζει τη θέληση με τη θεϊκή αλήθεια",
+      "bodyLocation": "Λαιμός, Αυχένας, Σαγόνι, Στόμα",
       "balanced": [
-        "Clear, honest communication",
-        "Authentic self-expression",
-        "Good listener",
-        "Strong voice and balanced speech"
+        "Σαφής, ειλικρινής επικοινωνία",
+        "Αυθεντική αυτοέκφραση",
+        "Καλός ακροατής",
+        "Δυνατή φωνή και ισορροπημένος λόγος"
       ],
       "unbalanced": [
-        "Fear of speaking up",
-        "Being unheard or misunderstood",
-        "People-pleasing",
-        "Suppressed feelings or lies"
+        "Φόβος να μιλήσει",
+        "Να μην ακούγεται ή να παρεξηγείται",
+        "Αρεσκεία",
+        "Καταπιεσμένα συναισθήματα ή ψέματα"
       ],
-      "blockages": "Suppressed Truth — Fear of Expression — Miscommunication"
+      "blockages": "Καταπιεσμένη Αλήθεια — Φόβος Έκφρασης — Κακή Επικοινωνία"
     },
     "l2-chakra-third-eye": {
-      "concept": "Third Eye Chakra",
-      "teachingText": "Ajna — Intuition & Insight",
-      "focus": "Imagination — Perception — Visualization",
-      "energy": "Feminine aspects of awareness",
-      "bodyLocation": "Forehead, Brow, Eye center",
+      "concept": "Τσάκρα του Τρίτου Ματιού",
+      "teachingText": "Ajna — Διαίσθηση και Ενόραση",
+      "focus": "Φαντασία — Αντίληψη — Οραματισμός",
+      "energy": "Θηλυκές πτυχές της επίγνωσης",
+      "bodyLocation": "Μέτωπο, Φρύδι, Κέντρο ματιού",
       "balanced": [
-        "Clear seeing and intuition",
-        "Good memory and imagination",
-        "Inner location",
-        "Wisdom and vision"
+        "Διαυγής όραση και διαίσθηση",
+        "Καλή μνήμη και φαντασία",
+        "Εσωτερική θέαση",
+        "Σοφία και όραμα"
       ],
       "unbalanced": [
-        "Overthinking",
-        "Mental fog",
-        "Disconnection with inner guidance",
-        "Escaping reality or spiritual bypassing"
+        "Υπερβολική σκέψη",
+        "Νοητική ομίχλη",
+        "Αποσύνδεση από την εσωτερική καθοδήγηση",
+        "Απόδραση από την πραγματικότητα ή πνευματική παράκαμψη"
       ],
-      "blockages": "Suppressed Truth — Fear of Expression — Miscommunication"
+      "blockages": "Καταπιεσμένη Αλήθεια — Φόβος Έκφρασης — Κακή Επικοινωνία"
     },
     "l2-chakra-crown": {
-      "concept": "Crown Chakra",
-      "teachingText": "Sahasrara — Spirituality & Consciousness",
-      "focus": "Spiritual Connection — Inner Wisdom — Higher States of Awareness",
-      "energy": "Transcending ego, merging with source",
-      "bodyLocation": "Top of head",
+      "concept": "Τσάκρα του Στέμματος",
+      "teachingText": "Sahasrara — Πνευματικότητα και Συνείδηση",
+      "focus": "Πνευματική Σύνδεση — Εσωτερική Σοφία — Ανώτερες Καταστάσεις Επίγνωσης",
+      "energy": "Υπέρβαση του εγώ, ενοποίηση με την πηγή",
+      "bodyLocation": "Κορυφή του κεφαλιού",
       "balanced": [
-        "Spiritual faith and connection",
-        "Inner peace, trust, and wisdom",
-        "Openness and awareness",
-        "Sense of life purpose"
+        "Πνευματική πίστη και σύνδεση",
+        "Εσωτερική ειρήνη, εμπιστοσύνη και σοφία",
+        "Ανοιχτότητα και επίγνωση",
+        "Αίσθηση σκοπού ζωής"
       ],
       "unbalanced": [
-        "Spiritual emptiness",
-        "Existential doubt",
-        "Feeling isolated or alone",
-        "Lack of purpose"
+        "Πνευματικό κενό",
+        "Υπαρξιακή αμφιβολία",
+        "Αίσθηση απομόνωσης ή μοναξιάς",
+        "Έλλειψη σκοπού"
       ],
-      "blockages": "Disconnection — Cynicism — Loss of Meaning"
+      "blockages": "Αποσύνδεση — Κυνισμός — Απώλεια Νοήματος"
     }
   },
-  "_translationStatus": "pending",
-  "_note": "This file contains English text as placeholder. All values need to be translated to the target language."
+  "_translationStatus": "complete"
 }

--- a/src/content/teaching/es.json
+++ b/src/content/teaching/es.json
@@ -1,350 +1,349 @@
 {
   "ui": {
-    "teacherVisualAidManual": "Teacher Visual Aid Manual",
-    "facilitatorCompanion": "A facilitator’s visual companion for teaching Rose Meditation.",
-    "selectTeachingLevel": "Select a Teaching Level",
-    "allLevels": "All Levels",
-    "level": "Level",
-    "slide": "Slide",
-    "designerNote": "Designer note",
-    "downloadPdf": "Download PDF",
-    "sacredSpace": "Sacred Space",
-    "theChakraSystem": "The Chakra System",
-    "cleansingAndRecovery": "Cleansing & Recovery",
-    "goldenStickyRoses": "Golden Sticky Roses",
-    "balancedExpression": "Balanced Expression",
-    "unbalancedExpression": "Unbalanced Expression",
-    "primaryBlockages": "Primary Blockages",
+    "teacherVisualAidManual": "Manual Visual para Profesores",
+    "facilitatorCompanion": "Un compañero visual del facilitador para la enseñanza de la Meditación de la Rosa.",
+    "selectTeachingLevel": "Seleccione un Nivel de Enseñanza",
+    "allLevels": "Todos los Niveles",
+    "level": "Nivel",
+    "slide": "Diapositiva",
+    "designerNote": "Nota del diseñador",
+    "downloadPdf": "Descargar PDF",
+    "sacredSpace": "Espacio Sagrado",
+    "theChakraSystem": "El Sistema de Chakras",
+    "cleansingAndRecovery": "Limpieza y Recuperación",
+    "goldenStickyRoses": "Rosas Doradas Adhesivas",
+    "balancedExpression": "Expresión Equilibrada",
+    "unbalancedExpression": "Expresión Desequilibrada",
+    "primaryBlockages": "Bloqueos Primarios",
     "color": "Color",
-    "element": "Element",
-    "location": "Location",
-    "energy": "Energy",
-    "focus": "Focus",
-    "lineage": "Lineage",
+    "element": "Elemento",
+    "location": "Ubicación",
+    "energy": "Energía",
+    "focus": "Enfoque",
+    "lineage": "Linaje",
     "rosesOs": "ROSES OS"
   },
   "opening": {
     "agreements": {
-      "title": "Agreements & Virtues",
-      "text": "Before beginning, all participants honor these agreements:",
+      "title": "Acuerdos y Virtudes",
+      "text": "Antes de comenzar, todos los participantes honran estos acuerdos:",
       "items": [
-        "Punctuality",
-        "Confidentiality",
-        "Co-responsibility",
-        "Trust",
-        "Patience, Empathy and Compassion"
+        "Puntualidad",
+        "Confidencialidad",
+        "Corresponsabilidad",
+        "Confianza",
+        "Paciencia, Empatía y Compasión"
       ]
     },
     "sacredCompanion": {
-      "title": "Sacred Companion",
+      "title": "Compañero Sagrado",
       "paragraphs": [
-        "This manual is a sacred companion for those who have been initiated into the path of Rose Meditation.",
-        "These teachings are part of a living energetic lineage. They invite inner stillness, gentle discipline, and deep self-responsibility. ROSES OS is not a system to be imposed or taught casually — it is an energetic operating system revealed through direct practice and transmission."
+        "Este manual es un compañero sagrado para quienes han sido iniciados en el camino de la Meditación de la Rosa.",
+        "Estas enseñanzas forman parte de un linaje energético vivo. Invitan a la quietud interior, la disciplina gentil y la profunda autorresponsabilidad. ROSES OS no es un sistema para ser impuesto o enseñado casualmente — es un sistema operativo energético revelado a través de la práctica directa y la transmisión."
       ],
-      "guidelinesTitle": "To honor the integrity of this work:",
+      "guidelinesTitle": "Para honrar la integridad de este trabajo:",
       "guidelinesItems": [
-        "Please do not share this material with others who have not received the transmission.",
-        "This manual is for personal use only and cannot be used to teach or guide others.",
-        "You are welcome to support children under your care with these tools."
+        "Por favor, no comparta este material con otras personas que no hayan recibido la transmisión.",
+        "Este manual es solo para uso personal y no puede ser utilizado para enseñar u orientar a otros.",
+        "Puede apoyar a los niños bajo su cuidado con estas herramientas."
       ],
-      "closing": "Let each page be a reminder of the sacred space within you."
+      "closing": "Que cada página sea un recordatorio del espacio sagrado dentro de usted."
     },
     "history": {
-      "title": "History & Lineage",
-      "text": "Aura Reading emerged in the 1960s, in California, channeled by a North American called Lewis S. Bostwick. Founder of the Berkeley Psychic Institute and the Church of the Divine Man, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.",
+      "title": "Historia y Linaje",
+      "text": "La Lectura del Aura surgió en la década de 1960, en California, canalizada por un norteamericano llamado Lewis S. Bostwick. Fundador del Berkeley Psychic Institute y de la Church of the Divine Man, canalizó y sistematizó las técnicas y herramientas enviadas por los ángeles, para asistir en el proceso de evolución de la humanidad.",
       "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → ROSES OS"
     }
   },
   "levels": {
     "1": {
-      "title": "Level 1: Foundation",
-      "subtitle": "Core Practices",
-      "description": "The essential practices that form the foundation of all ROSES OS work. Breath, body, heart, and the Rose Meditation."
+      "title": "Nivel 1: Fundamento",
+      "subtitle": "Prácticas Fundamentales",
+      "description": "Las prácticas esenciales que forman la base de todo el trabajo de ROSES OS. Respiración, cuerpo, corazón y la Meditación de la Rosa."
     },
     "2": {
-      "title": "Level 2: Deepening",
-      "subtitle": "Energetic & Relational",
-      "description": "Advanced practices for subtle body awareness, emotional alchemy, and relational coherence."
+      "title": "Nivel 2: Profundización",
+      "subtitle": "Energético y Relacional",
+      "description": "Prácticas avanzadas para la conciencia del cuerpo sutil, alquimia emocional y coherencia relacional."
     },
     "3": {
-      "title": "Level 3: Teaching",
-      "subtitle": "Transmission & Facilitation",
-      "description": "Practices and principles for holding space, transmitting the work, and serving as a guardian of the lineage."
+      "title": "Nivel 3: Enseñanza",
+      "subtitle": "Transmisión y Facilitación",
+      "description": "Prácticas y principios para sostener el espacio, transmitir el trabajo y servir como guardián del linaje."
     }
   },
   "slides": {
     "l1-the-rose": {
-      "concept": "The Rose",
-      "teachingText": "The Rose is the foundational symbol and tool of this practice — a living energetic instrument used throughout all levels of the work."
+      "concept": "La Rosa",
+      "teachingText": "La Rosa es el símbolo y la herramienta fundamental de esta práctica — un instrumento energético vivo utilizado en todos los niveles del trabajo."
     },
     "l1-posture": {
-      "concept": "Meditation Posture",
-      "teachingText": "Proper meditation posture is seated upright in a chair. Feet are flat on the floor, hands resting gently on the thighs or knees, spine upright, eyes closed. The body is relaxed yet alert — grounded and receptive."
+      "concept": "Postura de Meditación",
+      "teachingText": "La postura correcta de meditación es sentada erguida en una silla. Los pies están apoyados en el suelo, las manos descansando suavemente sobre los muslos o las rodillas, la columna erguida, los ojos cerrados. El cuerpo está relajado pero alerta — enraizado y receptivo."
     },
     "l1-grounding-cord": {
-      "concept": "Grounding Cord",
-      "teachingText": "The grounding cord is an energetic connection that extends from the base of the spine (first chakra) downward into the center of the Earth. It anchors your energy body to the planet, providing stability, safety, and a channel for releasing unwanted energy."
+      "concept": "Cordón de Enraizamiento",
+      "teachingText": "El cordón de enraizamiento es una conexión energética que se extiende desde la base de la columna (primer chakra) hacia abajo hasta el centro de la Tierra. Ancla su cuerpo energético al planeta, proporcionando estabilidad, seguridad y un canal para liberar energía no deseada."
     },
     "l1-golden-sun": {
-      "concept": "Golden Sun",
-      "teachingText": "The Golden Sun is a tool for replenishing and restoring your own energy. Visualize a radiant golden sun above your head. It calls back your own life-force energy from wherever you may have left it — in people, places, situations, or time. It fills you with your own highest vibration."
+      "concept": "Sol Dorado",
+      "teachingText": "El Sol Dorado es una herramienta para reabastecer y restaurar su propia energía. Visualice un sol dorado radiante sobre su cabeza. Llama de vuelta su propia energía vital de dondequiera que la haya dejado — en personas, lugares, situaciones o en el tiempo. Lo llena con su vibración más elevada."
     },
     "l1-aura-exercise": {
-      "concept": "An Exercise to Feel Your Aura",
-      "teachingText": "The aura is the energetic field that surrounds your physical body. This exercise helps you become aware of its presence, its edges, and its quality. The aura consists of multiple layers radiating outward from the body."
+      "concept": "Un Ejercicio para Sentir Su Aura",
+      "teachingText": "El aura es el campo energético que rodea su cuerpo físico. Este ejercicio le ayuda a tomar conciencia de su presencia, sus bordes y su calidad. El aura consiste en múltiples capas que irradian hacia afuera del cuerpo."
     },
     "l1-grounding-expansion": {
-      "concept": "Expansion of Grounding Cord",
-      "teachingText": "Once you are aware of your aura, the grounding cord practice deepens. You ground not only the physical body but also the aura itself — allowing the entire energy field to anchor into the Earth."
+      "concept": "Expansión del Cordón de Enraizamiento",
+      "teachingText": "Una vez que usted es consciente de su aura, la práctica del cordón de enraizamiento se profundiza. Usted enraíza no solo el cuerpo físico, sino también el aura misma — permitiendo que todo el campo energético se ancle en la Tierra."
     },
     "l1-full-setup": {
-      "concept": "Full Meditation Setup",
-      "teachingText": "The complete foundational setup combines posture, aura, and expanded grounding cord: the person is seated in proper posture, enclosed within their aura, with the grounding cord descending into the earth."
+      "concept": "Configuración Completa de la Meditación",
+      "teachingText": "La configuración fundamental completa combina postura, aura y cordón de enraizamiento expandido: la persona está sentada en postura correcta, envuelta dentro de su aura, con el cordón de enraizamiento descendiendo hacia la tierra."
     },
     "l1-golden-sun-fills": {
-      "concept": "Golden Sun Fills You",
-      "teachingText": "The Golden Sun above the crown pours golden light downward, filling the entire aura and body with your own highest vibration. This completes the full energetic architecture: posture, aura, grounding cord, and golden sun — all active together."
+      "concept": "El Sol Dorado Lo Llena",
+      "teachingText": "El Sol Dorado sobre la corona derrama luz dorada hacia abajo, llenando toda el aura y el cuerpo con su vibración más elevada. Esto completa la arquitectura energética completa: postura, aura, cordón de enraizamiento y sol dorado — todos activos juntos."
     },
     "l1-earth-circuit": {
-      "concept": "Circuit of the Energy of the Earth",
-      "teachingText": "The Earth circuit is an energetic pathway that draws the energy of the Earth upward through the feet, rising through the legs and into the body. This circuit connects you to the grounding, nourishing, stabilizing force of the planet."
+      "concept": "Circuito de la Energía de la Tierra",
+      "teachingText": "El circuito de la Tierra es un camino energético que atrae la energía de la Tierra hacia arriba a través de los pies, subiendo por las piernas y entrando al cuerpo. Este circuito lo conecta con la fuerza enraizadora, nutritiva y estabilizadora del planeta."
     },
     "l1-cosmos-circuit": {
-      "concept": "Circuit of the Energy of the Cosmos",
-      "teachingText": "The Cosmic circuit is an energetic pathway that draws cosmic energy downward through the crown of the head (7th chakra) and into the body. This circuit connects you to the higher frequencies of universal consciousness, inspiration, and spiritual guidance."
+      "concept": "Circuito de la Energía del Cosmos",
+      "teachingText": "El circuito Cósmico es un camino energético que atrae la energía cósmica hacia abajo a través de la corona de la cabeza (7º chakra) y hacia el interior del cuerpo. Este circuito lo conecta con las frecuencias más elevadas de la conciencia universal, la inspiración y la guía espiritual."
     },
     "l1-combined-circuit": {
-      "concept": "Circuit of Energy of Cosmos and Earth",
-      "teachingText": "When both circuits are activated simultaneously, the energies of the Earth and Cosmos flow together through the body. Earth energy rises from below; Cosmic energy descends from above. They meet and blend within the body, creating a unified field of balanced, integrated energy."
+      "concept": "Circuito de la Energía del Cosmos y de la Tierra",
+      "teachingText": "Cuando ambos circuitos se activan simultáneamente, las energías de la Tierra y del Cosmos fluyen juntas a través del cuerpo. La energía de la Tierra asciende desde abajo; la energía Cósmica desciende desde arriba. Se encuentran y se mezclan dentro del cuerpo, creando un campo unificado de energía equilibrada e integrada."
     },
     "l1-rose-tool": {
-      "concept": "The Rose (as Energetic Tool)",
-      "teachingText": "The Rose is used as a living energetic instrument throughout the practice. It has roots (connection to source), a stem (channel of energy), and a bloom (the active, radiant tool). The Rose can be placed, moved, opened, closed, and released according to the needs of the meditation."
+      "concept": "La Rosa (como Herramienta Energética)",
+      "teachingText": "La Rosa se utiliza como un instrumento energético vivo a lo largo de toda la práctica. Tiene raíces (conexión con la fuente), un tallo (canal de energía) y una flor (la herramienta activa y radiante). La Rosa puede ser colocada, movida, abierta, cerrada y liberada según las necesidades de la meditación."
     },
     "l1-four-roses": {
-      "concept": "Roses of Protection, Observation and Separation",
-      "teachingText": "Roses are placed at the edges of the aura to serve as energetic sentinels. They perform three functions:\n\n1. Protection — They define and guard the boundary of your aura\n2. Observation — They help you notice what energies are approaching or interacting with your field\n3. Separation — They create healthy energetic distinction between your energy and the energy of others"
+      "concept": "Rosas de Protección, Observación y Separación",
+      "teachingText": "Las Rosas se colocan en los bordes del aura para servir como centinelas energéticos. Cumplen tres funciones:\n\n1. Protección — Definen y protegen los límites de su aura\n2. Observación — Le ayudan a percibir qué energías se acercan o interactúan con su campo\n3. Separación — Crean una distinción energética saludable entre su energía y la energía de los demás"
     },
     "l1-cleansing-rose": {
-      "concept": "Cleansing Rose",
-      "teachingText": "The Cleansing Rose is placed outside of the aura. It is used to absorb and transmute foreign or stagnant energy from within your field. Energy that does not belong to you — from other people, environments, or experiences — is drawn out of the aura and into the Cleansing Rose, where it is neutralized."
+      "concept": "Rosa de Limpieza",
+      "teachingText": "La Rosa de Limpieza se coloca fuera del aura. Se utiliza para absorber y transmutar energía ajena o estancada de su campo. La energía que no le pertenece — de otras personas, ambientes o experiencias — es atraída fuera del aura y hacia la Rosa de Limpieza, donde es neutralizada."
     },
     "l1-energy-recovery": {
-      "concept": "Energy Recovery of Each Chakra",
-      "teachingText": "After cleansing, the Rose is used to recover your own energy that has been left in or taken by others. The Rose is sent out as an instrument to gather and return your own life-force energy to each chakra, restoring fullness and sovereignty to each energy center."
+      "concept": "Recuperación Energética de Cada Chakra",
+      "teachingText": "Después de la limpieza, la Rosa se utiliza para recuperar su propia energía que ha sido dejada o tomada por otros. La Rosa es enviada como un instrumento para reunir y devolver su propia energía vital a cada chakra, restaurando plenitud y soberanía a cada centro energético."
     },
     "l1-discharge": {
-      "concept": "Discharge Excess Energy",
-      "teachingText": "After deep meditation or energy work, excess energy may accumulate in the body. To discharge it, lean forward from the seated position with hands reaching toward the ground. Allow the excess energy to flow out through the hands and into the earth, returning the body to a calm, balanced state."
+      "concept": "Descarga del Exceso de Energía",
+      "teachingText": "Después de una meditación profunda o trabajo energético, el exceso de energía puede acumularse en el cuerpo. Para descargarlo, inclínese hacia adelante desde la posición sentada con las manos alcanzando el suelo. Permita que el exceso de energía fluya a través de las manos y entre en la tierra, devolviendo el cuerpo a un estado calmado y equilibrado."
     },
     "l2-sacred-space": {
-      "concept": "Let’s Create Your Sacred Space",
-      "teachingText": "Level 2 begins with creating your own sacred space — an internal energetic environment that serves as your meditation home. This is the space from which all deeper work is conducted."
+      "concept": "Creemos Su Espacio Sagrado",
+      "teachingText": "El Nivel 2 comienza con la creación de su propio espacio sagrado — un entorno energético interno que sirve como su hogar de meditación. Este es el espacio desde el cual se conduce todo el trabajo más profundo."
     },
     "l2-6th-7th-chakras": {
-      "concept": "The 6th and 7th Chakras (Sacred Space)",
-      "teachingText": "Understanding the locations and roles of the upper chakras is essential for Level 2 work:\n\n• 6th Chakra (Third Eye) — Located at the center of the forehead, between and slightly above the eyebrows\n• 7th Chakra (Crown) — Located at the top of the head"
+      "concept": "El 6º y el 7º Chakras (Espacio Sagrado)",
+      "teachingText": "Comprender las ubicaciones y funciones de los chakras superiores es esencial para el trabajo del Nivel 2:\n\n• 6º Chakra (Tercer Ojo) — Ubicado en el centro de la frente, entre y ligeramente por encima de las cejas\n• 7º Chakra (Corona) — Ubicado en la parte superior de la cabeza"
     },
     "l2-physical-space": {
-      "concept": "Let’s Prepare Your Physical Space",
-      "teachingText": "Before meditation, prepare your physical environment to support the energetic work. The external space should mirror the internal intention: clean, clear, quiet, and intentionally held."
+      "concept": "Preparemos Su Espacio Físico",
+      "teachingText": "Antes de la meditación, prepare su entorno físico para apoyar el trabajo energético. El espacio externo debe reflejar la intención interna: limpio, claro, silencioso y sostenido intencionalmente."
     },
     "l2-protection-space": {
-      "concept": "Protection of the Space",
-      "teachingText": "The physical meditation space is protected by creating an energetic grid using roses. Golden roses are placed at the four corners (and above/below) of the space, connected by lines of golden energy forming a sacred geometric structure — a container for the work."
+      "concept": "Protección del Espacio",
+      "teachingText": "El espacio físico de meditación se protege creando una rejilla energética usando rosas. Rosas doradas se colocan en las cuatro esquinas (y arriba/abajo) del espacio, conectadas por líneas de energía dorada formando una estructura geométrica sagrada — un contenedor para el trabajo."
     },
     "l2-cleansing-space": {
-      "concept": "Cleansing of the Space",
-      "teachingText": "Once the space is protected, it is cleansed. A large Cleansing Rose is placed above the grid, and golden energy pours downward through the entire structure, clearing all foreign, stagnant, or disruptive energies from the space."
+      "concept": "Limpieza del Espacio",
+      "teachingText": "Una vez que el espacio está protegido, se limpia. Una gran Rosa de Limpieza se coloca encima de la rejilla, y la energía dorada fluye hacia abajo a través de toda la estructura, limpiando todas las energías ajenas, estancadas o perturbadoras del espacio."
     },
     "l2-owning-space": {
-      "concept": "Owning Your Space",
-      "teachingText": "After protection and cleansing, you claim ownership of the space. This is an act of energetic sovereignty — declaring the space as yours, filling it with your own energy and intention. The space becomes an extension of your aura and your practice."
+      "concept": "Apropiarse de Su Espacio",
+      "teachingText": "Después de la protección y la limpieza, usted toma posesión del espacio. Este es un acto de soberanía energética — declarando el espacio como suyo, llenándolo con su propia energía e intención. El espacio se convierte en una extensión de su aura y de su práctica."
     },
     "l2-chakras-intro": {
-      "concept": "Let’s Talk About Chakras",
-      "teachingText": "The chakra system is the energetic anatomy of the human body. There are seven primary chakras, each governing specific aspects of physical, emotional, mental, and spiritual life."
+      "concept": "Hablemos de los Chakras",
+      "teachingText": "El sistema de chakras es la anatomía energética del cuerpo humano. Hay siete chakras primarios, cada uno gobernando aspectos específicos de la vida física, emocional, mental y espiritual."
     },
     "l2-seven-chakras": {
-      "concept": "The Seven Chakras",
-      "teachingText": "The seven primary chakras, from crown to root:\n\n7. Crown — Top of head\n6. Third Eye — Center of forehead\n5. Throat — Throat\n4. Heart — Center of chest\n3. Solar Plexus — Upper abdomen\n2. Sacral — Lower abdomen\n1. Root — Base of spine"
+      "concept": "Los Siete Chakras",
+      "teachingText": "Los siete chakras primarios, de la corona a la raíz:\n\n7. Corona — Parte superior de la cabeza\n6. Tercer Ojo — Centro de la frente\n5. Garganta — Garganta\n4. Corazón — Centro del pecho\n3. Plexo Solar — Abdomen superior\n2. Sacro — Abdomen inferior\n1. Raíz — Base de la columna"
     },
     "l2-cleansing-aura-layers": {
-      "concept": "Cleansing of Each Aura Layer",
-      "teachingText": "The aura is composed of seven layers, each corresponding to a chakra. In Level 2, each layer is individually cleansed from the outermost to the innermost:\n\n7. 7th Aura layer\n6. 6th Aura layer\n5. 5th Aura layer\n4. 4th Aura layer\n3. 3rd Aura layer\n2. 2nd Aura layer\n1. 1st Aura layer"
+      "concept": "Limpieza de Cada Capa del Aura",
+      "teachingText": "El aura se compone de siete capas, cada una correspondiente a un chakra. En el Nivel 2, cada capa se limpia individualmente desde la más externa hasta la más interna:\n\n7. 7ª capa del Aura\n6. 6ª capa del Aura\n5. 5ª capa del Aura\n4. 4ª capa del Aura\n3. 3ª capa del Aura\n2. 2ª capa del Aura\n1. 1ª capa del Aura"
     },
     "l2-cleansing-each-chakra": {
-      "concept": "Cleansing of Each Chakra",
-      "teachingText": "Each individual chakra is cleansed using roses. The roses address two dimensions:\n\n• Dynamics of the Past — Energetic patterns, imprints, and blockages carried from past experiences\n• Dynamics of the Present — Current energetic influences, relationships, and situations affecting the chakra"
+      "concept": "Limpieza de Cada Chakra",
+      "teachingText": "Cada chakra individual se limpia usando rosas. Las rosas abordan dos dimensiones:\n\n• Dinámicas del Pasado — Patrones energéticos, impresiones y bloqueos cargados de experiencias pasadas\n• Dinámicas del Presente — Influencias energéticas actuales, relaciones y situaciones que afectan el chakra"
     },
     "l2-energy-recovery": {
-      "concept": "Energy Recovery of Each Chakra (Level 2)",
-      "teachingText": "After cleansing, the energy recovery process is repeated at a deeper level. The Rose is sent out to gather and return your own energy to each individual chakra, restoring sovereignty, vitality, and wholeness to each energy center."
+      "concept": "Recuperación Energética de Cada Chakra (Nivel 2)",
+      "teachingText": "Después de la limpieza, el proceso de recuperación energética se repite a un nivel más profundo. La Rosa es enviada para reunir y devolver su propia energía a cada chakra individual, restaurando soberanía, vitalidad e integridad a cada centro energético."
     },
     "l2-golden-sticky-1": {
-      "concept": "Golden Sticky Roses — Phase 1 (Chakra Placement)",
-      "teachingText": "Golden sticky roses are placed on each of the seven chakras, drawing out foreign energy lodged in the energy centers."
+      "concept": "Rosas Doradas Adhesivas — Fase 1 (Colocación en los Chakras)",
+      "teachingText": "Las rosas doradas adhesivas se colocan en cada uno de los siete chakras, extrayendo energía ajena alojada en los centros energéticos."
     },
     "l2-golden-sticky-2": {
-      "concept": "Golden Sticky Roses — Phase 2 (Body Placement)",
-      "teachingText": "Golden sticky roses are placed at the joints and extremities of the body — shoulders, elbows, wrists, hands, hips, knees, ankles, feet — drawing out foreign energy stored in the physical body."
+      "concept": "Rosas Doradas Adhesivas — Fase 2 (Colocación en el Cuerpo)",
+      "teachingText": "Las rosas doradas adhesivas se colocan en las articulaciones y extremidades del cuerpo — hombros, codos, muñecas, manos, caderas, rodillas, tobillos, pies — extrayendo energía ajena almacenada en el cuerpo físico."
     },
     "l2-golden-sticky-3": {
-      "concept": "Golden Sticky Roses — Phase 3 (Full Body Coverage)",
-      "teachingText": "Golden sticky roses are placed throughout the entire body — covering the torso, limbs, and all remaining areas — for a thorough, complete energetic cleansing."
+      "concept": "Rosas Doradas Adhesivas — Fase 3 (Cobertura Total del Cuerpo)",
+      "teachingText": "Las rosas doradas adhesivas se colocan por todo el cuerpo — cubriendo el torso, las extremidades y todas las áreas restantes — para una limpieza energética completa y profunda."
     },
     "l2-golden-sticky-4": {
-      "concept": "Golden Sticky Roses — Phase 4 (Integration)",
-      "teachingText": "After the golden sticky roses have done their work, a large Golden Rose appears above the head. All foreign energy gathered by the sticky roses is released, and the entire body is bathed in golden light — restoring, sealing, and integrating the energy body."
+      "concept": "Rosas Doradas Adhesivas — Fase 4 (Integración)",
+      "teachingText": "Después de que las rosas doradas adhesivas han realizado su trabajo, una gran Rosa Dorada aparece sobre la cabeza. Toda la energía ajena reunida por las rosas adhesivas es liberada, y todo el cuerpo es bañado en luz dorada — restaurando, sellando e integrando el cuerpo energético."
     },
     "l3-analyzer": {
-      "concept": "The Analyzer",
-      "teachingText": "The Analyzer is an advanced tool introduced in Level 3. It is an energetic point located at the back of the head, at the base of the skull (the occipital ridge / brainstem area). The Analyzer is used for deeper perception, reading, and discernment of energy — a tool for precise energetic analysis."
+      "concept": "El Analizador",
+      "teachingText": "El Analizador es una herramienta avanzada introducida en el Nivel 3. Es un punto energético ubicado en la parte posterior de la cabeza, en la base del cráneo (la cresta occipital / área del tronco encefálico). El Analizador se utiliza para una percepción más profunda, lectura y discernimiento de energía — una herramienta para el análisis energético preciso."
     }
   },
   "chakras": {
     "l2-chakra-root": {
-      "concept": "Root Chakra",
-      "teachingText": "Muladhara — Grounding & Safety",
-      "focus": "Stability — Safety — Embodiment",
-      "energy": "Masculine — Survival / Foundation",
-      "bodyLocation": "Base of spine, Legs, Feet",
+      "concept": "Chakra Raíz",
+      "teachingText": "Muladhara — Enraizamiento y Seguridad",
+      "focus": "Estabilidad — Seguridad — Corporización",
+      "energy": "Masculino — Supervivencia / Fundamento",
+      "bodyLocation": "Base de la columna, Piernas, Pies",
       "balanced": [
-        "Grounded presence",
-        "Physical vitality",
-        "Trust in life",
-        "Feeling safe in the body"
+        "Presencia enraizada",
+        "Vitalidad física",
+        "Confianza en la vida",
+        "Sentirse seguro en el cuerpo"
       ],
       "unbalanced": [
-        "Fear and insecurity",
-        "Survival anxiety",
-        "Disconnection from body",
-        "Scarcity mindset"
+        "Miedo e inseguridad",
+        "Ansiedad de supervivencia",
+        "Desconexión del cuerpo",
+        "Mentalidad de escasez"
       ],
-      "blockages": "Fear — Insecurity — Survival Trauma"
+      "blockages": "Miedo — Inseguridad — Trauma de Supervivencia"
     },
     "l2-chakra-sacral": {
-      "concept": "Sacral Chakra",
-      "teachingText": "Svadhisthana — Emotion & Creativity",
-      "focus": "Emotions — Creativity — Pleasure",
-      "energy": "Feminine — Flow & Flexibility",
-      "bodyLocation": "Lower abdomen, Sexual Organs",
+      "concept": "Chakra Sacro",
+      "teachingText": "Svadhisthana — Emoción y Creatividad",
+      "focus": "Emociones — Creatividad — Placer",
+      "energy": "Femenino — Flujo y Flexibilidad",
+      "bodyLocation": "Abdomen inferior, Órganos Sexuales",
       "balanced": [
-        "Emotional well-being",
-        "Sensuality and intimacy",
-        "Passion and pleasure",
-        "Adaptability"
+        "Bienestar emocional",
+        "Sensualidad e intimidad",
+        "Pasión y placer",
+        "Adaptabilidad"
       ],
       "unbalanced": [
-        "Depression and numbness",
-        "Sexual dysfunction",
-        "Emotional instability",
-        "Fear of change"
+        "Depresión y entumecimiento",
+        "Disfunción sexual",
+        "Inestabilidad emocional",
+        "Miedo al cambio"
       ],
-      "blockages": "Shame — Emotional Repression — Guilt"
+      "blockages": "Vergüenza — Represión Emocional — Culpa"
     },
     "l2-chakra-solar-plexus": {
-      "concept": "Solar Plexus Chakra",
-      "teachingText": "Manipura — Willpower & Confidence",
-      "focus": "Personal Power — Self-Esteem — Drive",
-      "energy": "Masculine — Power & Transformation",
-      "bodyLocation": "Upper abdomen, Diaphragm",
+      "concept": "Chakra del Plexo Solar",
+      "teachingText": "Manipura — Fuerza de Voluntad y Confianza",
+      "focus": "Poder Personal — Autoestima — Determinación",
+      "energy": "Masculino — Poder y Transformación",
+      "bodyLocation": "Abdomen superior, Diafragma",
       "balanced": [
-        "Confidence and motivation",
-        "Responsible and disciplined",
-        "Healthy sense of self",
-        "Autonomy"
+        "Confianza y motivación",
+        "Responsable y disciplinado",
+        "Sentido saludable de sí mismo",
+        "Autonomía"
       ],
       "unbalanced": [
-        "Low self-esteem",
-        "Aggression or controlling",
-        "Stubborn and domineering",
-        "Lack of direction or purpose"
+        "Baja autoestima",
+        "Agresión o control",
+        "Terco y dominante",
+        "Falta de dirección o propósito"
       ],
-      "blockages": "Self-Doubt — Insecurity — Fear of Rejection"
+      "blockages": "Autoduda — Inseguridad — Miedo al Rechazo"
     },
     "l2-chakra-heart": {
-      "concept": "Heart Chakra",
-      "teachingText": "Anahata — Love & Integration",
-      "focus": "Love — Compassion — Connection",
-      "energy": "Bridge between physical & spiritual",
-      "bodyLocation": "Center of chest, Heart, Lungs",
+      "concept": "Chakra del Corazón",
+      "teachingText": "Anahata — Amor e Integración",
+      "focus": "Amor — Compasión — Conexión",
+      "energy": "Puente entre lo físico y lo espiritual",
+      "bodyLocation": "Centro del pecho, Corazón, Pulmones",
       "balanced": [
-        "Compassion and empathy",
-        "Emotional openness",
-        "Forgiveness",
-        "Healthy intimacy and self-love"
+        "Compasión y empatía",
+        "Apertura emocional",
+        "Perdón",
+        "Intimidad saludable y amor propio"
       ],
       "unbalanced": [
-        "Emotional withdrawal or over-giving",
-        "Fear of intimacy",
-        "Cold or detachment",
-        "Difficulty forgiving"
+        "Retraimiento emocional o entrega excesiva",
+        "Miedo a la intimidad",
+        "Frialdad o distanciamiento",
+        "Dificultad para perdonar"
       ],
-      "blockages": "Grief — Betrayal — Heartbreak",
-      "extraContent": "Human Love & Spiritual Love:\n\nHuman Love — Statement: I LOVE — Empathy, compassion, forgiveness, healthy relationships, romantic and familial love.\n\nSpiritual Love — Statement: I AM LOVE — Unconditional compassion, interconnectedness, divine and universal love, oneness."
+      "blockages": "Duelo — Traición — Corazón Roto",
+      "extraContent": "Amor Humano y Amor Espiritual:\n\nAmor Humano — Declaración: YO AMO — Empatía, compasión, perdón, relaciones saludables, amor romántico y familiar.\n\nAmor Espiritual — Declaración: YO SOY AMOR — Compasión incondicional, interconectividad, amor divino y universal, unidad."
     },
     "l2-chakra-throat": {
-      "concept": "Throat Chakra",
-      "teachingText": "Vishuddha — Communication & Expression",
-      "focus": "Communication — Truth — Authenticity",
-      "energy": "Learning to align will with divine truth",
-      "bodyLocation": "Throat, Neck, Jaw, Mouth",
+      "concept": "Chakra de la Garganta",
+      "teachingText": "Vishuddha — Comunicación y Expresión",
+      "focus": "Comunicación — Verdad — Autenticidad",
+      "energy": "Aprendiendo a alinear la voluntad con la verdad divina",
+      "bodyLocation": "Garganta, Cuello, Mandíbula, Boca",
       "balanced": [
-        "Clear, honest communication",
-        "Authentic self-expression",
-        "Good listener",
-        "Strong voice and balanced speech"
+        "Comunicación clara y honesta",
+        "Autoexpresión auténtica",
+        "Buen oyente",
+        "Voz fuerte y habla equilibrada"
       ],
       "unbalanced": [
-        "Fear of speaking up",
-        "Being unheard or misunderstood",
-        "People-pleasing",
-        "Suppressed feelings or lies"
+        "Miedo a expresarse",
+        "No ser escuchado o ser malinterpretado",
+        "Complacer a los demás",
+        "Sentimientos reprimidos o mentiras"
       ],
-      "blockages": "Suppressed Truth — Fear of Expression — Miscommunication"
+      "blockages": "Verdad Reprimida — Miedo a la Expresión — Falta de Comunicación"
     },
     "l2-chakra-third-eye": {
-      "concept": "Third Eye Chakra",
-      "teachingText": "Ajna — Intuition & Insight",
-      "focus": "Imagination — Perception — Visualization",
-      "energy": "Feminine aspects of awareness",
-      "bodyLocation": "Forehead, Brow, Eye center",
+      "concept": "Chakra del Tercer Ojo",
+      "teachingText": "Ajna — Intuición y Percepción",
+      "focus": "Imaginación — Percepción — Visualización",
+      "energy": "Aspectos femeninos de la conciencia",
+      "bodyLocation": "Frente, Cejas, Centro del ojo",
       "balanced": [
-        "Clear seeing and intuition",
-        "Good memory and imagination",
-        "Inner location",
-        "Wisdom and vision"
+        "Visión clara e intuición",
+        "Buena memoria e imaginación",
+        "Ubicación interior",
+        "Sabiduría y visión"
       ],
       "unbalanced": [
-        "Overthinking",
-        "Mental fog",
-        "Disconnection with inner guidance",
-        "Escaping reality or spiritual bypassing"
+        "Pensamiento excesivo",
+        "Niebla mental",
+        "Desconexión con la guía interior",
+        "Escapismo o evasión espiritual"
       ],
-      "blockages": "Suppressed Truth — Fear of Expression — Miscommunication"
+      "blockages": "Verdad Reprimida — Miedo a la Expresión — Falta de Comunicación"
     },
     "l2-chakra-crown": {
-      "concept": "Crown Chakra",
-      "teachingText": "Sahasrara — Spirituality & Consciousness",
-      "focus": "Spiritual Connection — Inner Wisdom — Higher States of Awareness",
-      "energy": "Transcending ego, merging with source",
-      "bodyLocation": "Top of head",
+      "concept": "Chakra de la Corona",
+      "teachingText": "Sahasrara — Espiritualidad y Conciencia",
+      "focus": "Conexión Espiritual — Sabiduría Interior — Estados Superiores de Conciencia",
+      "energy": "Trascendiendo el ego, fundiéndose con la fuente",
+      "bodyLocation": "Parte superior de la cabeza",
       "balanced": [
-        "Spiritual faith and connection",
-        "Inner peace, trust, and wisdom",
-        "Openness and awareness",
-        "Sense of life purpose"
+        "Fe y conexión espiritual",
+        "Paz interior, confianza y sabiduría",
+        "Apertura y conciencia",
+        "Sentido de propósito de vida"
       ],
       "unbalanced": [
-        "Spiritual emptiness",
-        "Existential doubt",
-        "Feeling isolated or alone",
-        "Lack of purpose"
+        "Vacío espiritual",
+        "Duda existencial",
+        "Sentirse aislado o solo",
+        "Falta de propósito"
       ],
-      "blockages": "Disconnection — Cynicism — Loss of Meaning"
+      "blockages": "Desconexión — Cinismo — Pérdida de Significado"
     }
   },
-  "_translationStatus": "pending",
-  "_note": "This file contains English text as placeholder. All values need to be translated to the target language."
+  "_translationStatus": "complete"
 }

--- a/src/content/teaching/pt.json
+++ b/src/content/teaching/pt.json
@@ -1,350 +1,349 @@
 {
   "ui": {
-    "teacherVisualAidManual": "Teacher Visual Aid Manual",
-    "facilitatorCompanion": "A facilitator’s visual companion for teaching Rose Meditation.",
-    "selectTeachingLevel": "Select a Teaching Level",
-    "allLevels": "All Levels",
-    "level": "Level",
+    "teacherVisualAidManual": "Manual Visual para Professores",
+    "facilitatorCompanion": "Um companheiro visual do facilitador para o ensino da Meditação da Rosa.",
+    "selectTeachingLevel": "Selecione um Nível de Ensino",
+    "allLevels": "Todos os Níveis",
+    "level": "Nível",
     "slide": "Slide",
-    "designerNote": "Designer note",
-    "downloadPdf": "Download PDF",
-    "sacredSpace": "Sacred Space",
-    "theChakraSystem": "The Chakra System",
-    "cleansingAndRecovery": "Cleansing & Recovery",
-    "goldenStickyRoses": "Golden Sticky Roses",
-    "balancedExpression": "Balanced Expression",
-    "unbalancedExpression": "Unbalanced Expression",
-    "primaryBlockages": "Primary Blockages",
-    "color": "Color",
-    "element": "Element",
-    "location": "Location",
-    "energy": "Energy",
-    "focus": "Focus",
-    "lineage": "Lineage",
+    "designerNote": "Nota do designer",
+    "downloadPdf": "Baixar PDF",
+    "sacredSpace": "Espaço Sagrado",
+    "theChakraSystem": "O Sistema de Chakras",
+    "cleansingAndRecovery": "Limpeza e Recuperação",
+    "goldenStickyRoses": "Rosas Douradas Adesivas",
+    "balancedExpression": "Expressão Equilibrada",
+    "unbalancedExpression": "Expressão Desequilibrada",
+    "primaryBlockages": "Bloqueios Primários",
+    "color": "Cor",
+    "element": "Elemento",
+    "location": "Localização",
+    "energy": "Energia",
+    "focus": "Foco",
+    "lineage": "Linhagem",
     "rosesOs": "ROSES OS"
   },
   "opening": {
     "agreements": {
-      "title": "Agreements & Virtues",
-      "text": "Before beginning, all participants honor these agreements:",
+      "title": "Acordos e Virtudes",
+      "text": "Antes de começar, todos os participantes honram estes acordos:",
       "items": [
-        "Punctuality",
-        "Confidentiality",
-        "Co-responsibility",
-        "Trust",
-        "Patience, Empathy and Compassion"
+        "Pontualidade",
+        "Confidencialidade",
+        "Corresponsabilidade",
+        "Confiança",
+        "Paciência, Empatia e Compaixão"
       ]
     },
     "sacredCompanion": {
-      "title": "Sacred Companion",
+      "title": "Companheiro Sagrado",
       "paragraphs": [
-        "This manual is a sacred companion for those who have been initiated into the path of Rose Meditation.",
-        "These teachings are part of a living energetic lineage. They invite inner stillness, gentle discipline, and deep self-responsibility. ROSES OS is not a system to be imposed or taught casually — it is an energetic operating system revealed through direct practice and transmission."
+        "Este manual é um companheiro sagrado para aqueles que foram iniciados no caminho da Meditação da Rosa.",
+        "Estes ensinamentos fazem parte de uma linhagem energética viva. Eles convidam à quietude interior, à disciplina gentil e à profunda autorresponsabilidade. ROSES OS não é um sistema para ser imposto ou ensinado casualmente — é um sistema operacional energético revelado através da prática direta e da transmissão."
       ],
-      "guidelinesTitle": "To honor the integrity of this work:",
+      "guidelinesTitle": "Para honrar a integridade deste trabalho:",
       "guidelinesItems": [
-        "Please do not share this material with others who have not received the transmission.",
-        "This manual is for personal use only and cannot be used to teach or guide others.",
-        "You are welcome to support children under your care with these tools."
+        "Por favor, não compartilhe este material com outras pessoas que não receberam a transmissão.",
+        "Este manual é apenas para uso pessoal e não pode ser usado para ensinar ou orientar outros.",
+        "Você pode apoiar crianças sob seus cuidados com estas ferramentas."
       ],
-      "closing": "Let each page be a reminder of the sacred space within you."
+      "closing": "Que cada página seja um lembrete do espaço sagrado dentro de você."
     },
     "history": {
-      "title": "History & Lineage",
-      "text": "Aura Reading emerged in the 1960s, in California, channeled by a North American called Lewis S. Bostwick. Founder of the Berkeley Psychic Institute and the Church of the Divine Man, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.",
+      "title": "História e Linhagem",
+      "text": "A Leitura de Aura surgiu na década de 1960, na Califórnia, canalizada por um norte-americano chamado Lewis S. Bostwick. Fundador do Berkeley Psychic Institute e da Church of the Divine Man, ele canalizou e sistematizou as técnicas e ferramentas enviadas pelos anjos, para auxiliar no processo de evolução da humanidade.",
       "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → ROSES OS"
     }
   },
   "levels": {
     "1": {
-      "title": "Level 1: Foundation",
-      "subtitle": "Core Practices",
-      "description": "The essential practices that form the foundation of all ROSES OS work. Breath, body, heart, and the Rose Meditation."
+      "title": "Nível 1: Fundação",
+      "subtitle": "Práticas Fundamentais",
+      "description": "As práticas essenciais que formam a base de todo o trabalho do ROSES OS. Respiração, corpo, coração e a Meditação da Rosa."
     },
     "2": {
-      "title": "Level 2: Deepening",
-      "subtitle": "Energetic & Relational",
-      "description": "Advanced practices for subtle body awareness, emotional alchemy, and relational coherence."
+      "title": "Nível 2: Aprofundamento",
+      "subtitle": "Energético e Relacional",
+      "description": "Práticas avançadas para a consciência do corpo sutil, alquimia emocional e coerência relacional."
     },
     "3": {
-      "title": "Level 3: Teaching",
-      "subtitle": "Transmission & Facilitation",
-      "description": "Practices and principles for holding space, transmitting the work, and serving as a guardian of the lineage."
+      "title": "Nível 3: Ensino",
+      "subtitle": "Transmissão e Facilitação",
+      "description": "Práticas e princípios para manter o espaço, transmitir o trabalho e servir como guardião da linhagem."
     }
   },
   "slides": {
     "l1-the-rose": {
-      "concept": "The Rose",
-      "teachingText": "The Rose is the foundational symbol and tool of this practice — a living energetic instrument used throughout all levels of the work."
+      "concept": "A Rosa",
+      "teachingText": "A Rosa é o símbolo e ferramenta fundamental desta prática — um instrumento energético vivo usado em todos os níveis do trabalho."
     },
     "l1-posture": {
-      "concept": "Meditation Posture",
-      "teachingText": "Proper meditation posture is seated upright in a chair. Feet are flat on the floor, hands resting gently on the thighs or knees, spine upright, eyes closed. The body is relaxed yet alert — grounded and receptive."
+      "concept": "Postura de Meditação",
+      "teachingText": "A postura correta de meditação é sentada ereta em uma cadeira. Os pés estão apoiados no chão, as mãos descansando suavemente sobre as coxas ou joelhos, a coluna ereta, os olhos fechados. O corpo está relaxado, porém alerta — enraizado e receptivo."
     },
     "l1-grounding-cord": {
-      "concept": "Grounding Cord",
-      "teachingText": "The grounding cord is an energetic connection that extends from the base of the spine (first chakra) downward into the center of the Earth. It anchors your energy body to the planet, providing stability, safety, and a channel for releasing unwanted energy."
+      "concept": "Cordão de Enraizamento",
+      "teachingText": "O cordão de enraizamento é uma conexão energética que se estende da base da coluna (primeiro chakra) até o centro da Terra. Ele ancora seu corpo energético ao planeta, proporcionando estabilidade, segurança e um canal para liberar energia indesejada."
     },
     "l1-golden-sun": {
-      "concept": "Golden Sun",
-      "teachingText": "The Golden Sun is a tool for replenishing and restoring your own energy. Visualize a radiant golden sun above your head. It calls back your own life-force energy from wherever you may have left it — in people, places, situations, or time. It fills you with your own highest vibration."
+      "concept": "Sol Dourado",
+      "teachingText": "O Sol Dourado é uma ferramenta para reabastecer e restaurar sua própria energia. Visualize um sol dourado radiante acima da sua cabeça. Ele chama de volta sua própria energia vital de onde quer que você a tenha deixado — em pessoas, lugares, situações ou no tempo. Ele preenche você com sua vibração mais elevada."
     },
     "l1-aura-exercise": {
-      "concept": "An Exercise to Feel Your Aura",
-      "teachingText": "The aura is the energetic field that surrounds your physical body. This exercise helps you become aware of its presence, its edges, and its quality. The aura consists of multiple layers radiating outward from the body."
+      "concept": "Um Exercício para Sentir Sua Aura",
+      "teachingText": "A aura é o campo energético que envolve o seu corpo físico. Este exercício ajuda você a tomar consciência de sua presença, seus limites e sua qualidade. A aura consiste em múltiplas camadas que irradiam para fora do corpo."
     },
     "l1-grounding-expansion": {
-      "concept": "Expansion of Grounding Cord",
-      "teachingText": "Once you are aware of your aura, the grounding cord practice deepens. You ground not only the physical body but also the aura itself — allowing the entire energy field to anchor into the Earth."
+      "concept": "Expansão do Cordão de Enraizamento",
+      "teachingText": "Uma vez que você está consciente da sua aura, a prática do cordão de enraizamento se aprofunda. Você enraíza não apenas o corpo físico, mas também a própria aura — permitindo que todo o campo energético se ancore na Terra."
     },
     "l1-full-setup": {
-      "concept": "Full Meditation Setup",
-      "teachingText": "The complete foundational setup combines posture, aura, and expanded grounding cord: the person is seated in proper posture, enclosed within their aura, with the grounding cord descending into the earth."
+      "concept": "Configuração Completa da Meditação",
+      "teachingText": "A configuração fundamental completa combina postura, aura e cordão de enraizamento expandido: a pessoa está sentada em postura correta, envolvida por sua aura, com o cordão de enraizamento descendo até a terra."
     },
     "l1-golden-sun-fills": {
-      "concept": "Golden Sun Fills You",
-      "teachingText": "The Golden Sun above the crown pours golden light downward, filling the entire aura and body with your own highest vibration. This completes the full energetic architecture: posture, aura, grounding cord, and golden sun — all active together."
+      "concept": "O Sol Dourado Preenche Você",
+      "teachingText": "O Sol Dourado acima da coroa derrama luz dourada para baixo, preenchendo toda a aura e o corpo com sua vibração mais elevada. Isso completa a arquitetura energética completa: postura, aura, cordão de enraizamento e sol dourado — todos ativos juntos."
     },
     "l1-earth-circuit": {
-      "concept": "Circuit of the Energy of the Earth",
-      "teachingText": "The Earth circuit is an energetic pathway that draws the energy of the Earth upward through the feet, rising through the legs and into the body. This circuit connects you to the grounding, nourishing, stabilizing force of the planet."
+      "concept": "Circuito da Energia da Terra",
+      "teachingText": "O circuito da Terra é um caminho energético que atrai a energia da Terra para cima através dos pés, subindo pelas pernas e entrando no corpo. Este circuito conecta você à força enraizadora, nutritiva e estabilizadora do planeta."
     },
     "l1-cosmos-circuit": {
-      "concept": "Circuit of the Energy of the Cosmos",
-      "teachingText": "The Cosmic circuit is an energetic pathway that draws cosmic energy downward through the crown of the head (7th chakra) and into the body. This circuit connects you to the higher frequencies of universal consciousness, inspiration, and spiritual guidance."
+      "concept": "Circuito da Energia do Cosmos",
+      "teachingText": "O circuito Cósmico é um caminho energético que atrai a energia cósmica para baixo através da coroa da cabeça (7º chakra) e para dentro do corpo. Este circuito conecta você às frequências mais elevadas da consciência universal, inspiração e orientação espiritual."
     },
     "l1-combined-circuit": {
-      "concept": "Circuit of Energy of Cosmos and Earth",
-      "teachingText": "When both circuits are activated simultaneously, the energies of the Earth and Cosmos flow together through the body. Earth energy rises from below; Cosmic energy descends from above. They meet and blend within the body, creating a unified field of balanced, integrated energy."
+      "concept": "Circuito da Energia do Cosmos e da Terra",
+      "teachingText": "Quando ambos os circuitos são ativados simultaneamente, as energias da Terra e do Cosmos fluem juntas através do corpo. A energia da Terra sobe de baixo; a energia Cósmica desce de cima. Elas se encontram e se misturam dentro do corpo, criando um campo unificado de energia equilibrada e integrada."
     },
     "l1-rose-tool": {
-      "concept": "The Rose (as Energetic Tool)",
-      "teachingText": "The Rose is used as a living energetic instrument throughout the practice. It has roots (connection to source), a stem (channel of energy), and a bloom (the active, radiant tool). The Rose can be placed, moved, opened, closed, and released according to the needs of the meditation."
+      "concept": "A Rosa (como Ferramenta Energética)",
+      "teachingText": "A Rosa é usada como um instrumento energético vivo ao longo de toda a prática. Ela possui raízes (conexão com a fonte), um caule (canal de energia) e uma flor (a ferramenta ativa e radiante). A Rosa pode ser colocada, movida, aberta, fechada e liberada de acordo com as necessidades da meditação."
     },
     "l1-four-roses": {
-      "concept": "Roses of Protection, Observation and Separation",
-      "teachingText": "Roses are placed at the edges of the aura to serve as energetic sentinels. They perform three functions:\n\n1. Protection — They define and guard the boundary of your aura\n2. Observation — They help you notice what energies are approaching or interacting with your field\n3. Separation — They create healthy energetic distinction between your energy and the energy of others"
+      "concept": "Rosas de Proteção, Observação e Separação",
+      "teachingText": "As Rosas são colocadas nas bordas da aura para servirem como sentinelas energéticas. Elas desempenham três funções:\n\n1. Proteção — Elas definem e guardam os limites da sua aura\n2. Observação — Elas ajudam você a perceber quais energias estão se aproximando ou interagindo com o seu campo\n3. Separação — Elas criam uma distinção energética saudável entre a sua energia e a energia dos outros"
     },
     "l1-cleansing-rose": {
-      "concept": "Cleansing Rose",
-      "teachingText": "The Cleansing Rose is placed outside of the aura. It is used to absorb and transmute foreign or stagnant energy from within your field. Energy that does not belong to you — from other people, environments, or experiences — is drawn out of the aura and into the Cleansing Rose, where it is neutralized."
+      "concept": "Rosa de Limpeza",
+      "teachingText": "A Rosa de Limpeza é colocada fora da aura. Ela é usada para absorver e transmutar energia estranha ou estagnada do seu campo. Energia que não pertence a você — de outras pessoas, ambientes ou experiências — é atraída para fora da aura e para dentro da Rosa de Limpeza, onde é neutralizada."
     },
     "l1-energy-recovery": {
-      "concept": "Energy Recovery of Each Chakra",
-      "teachingText": "After cleansing, the Rose is used to recover your own energy that has been left in or taken by others. The Rose is sent out as an instrument to gather and return your own life-force energy to each chakra, restoring fullness and sovereignty to each energy center."
+      "concept": "Recuperação Energética de Cada Chakra",
+      "teachingText": "Após a limpeza, a Rosa é usada para recuperar sua própria energia que foi deixada ou tomada por outros. A Rosa é enviada como um instrumento para reunir e devolver sua própria energia vital a cada chakra, restaurando plenitude e soberania a cada centro energético."
     },
     "l1-discharge": {
-      "concept": "Discharge Excess Energy",
-      "teachingText": "After deep meditation or energy work, excess energy may accumulate in the body. To discharge it, lean forward from the seated position with hands reaching toward the ground. Allow the excess energy to flow out through the hands and into the earth, returning the body to a calm, balanced state."
+      "concept": "Descarga do Excesso de Energia",
+      "teachingText": "Após meditação profunda ou trabalho energético, o excesso de energia pode se acumular no corpo. Para descarregá-lo, incline-se para frente a partir da posição sentada com as mãos alcançando o chão. Permita que o excesso de energia flua pelas mãos e entre na terra, retornando o corpo a um estado calmo e equilibrado."
     },
     "l2-sacred-space": {
-      "concept": "Let’s Create Your Sacred Space",
-      "teachingText": "Level 2 begins with creating your own sacred space — an internal energetic environment that serves as your meditation home. This is the space from which all deeper work is conducted."
+      "concept": "Vamos Criar Seu Espaço Sagrado",
+      "teachingText": "O Nível 2 começa com a criação do seu próprio espaço sagrado — um ambiente energético interno que serve como seu lar de meditação. Este é o espaço a partir do qual todo o trabalho mais profundo é conduzido."
     },
     "l2-6th-7th-chakras": {
-      "concept": "The 6th and 7th Chakras (Sacred Space)",
-      "teachingText": "Understanding the locations and roles of the upper chakras is essential for Level 2 work:\n\n• 6th Chakra (Third Eye) — Located at the center of the forehead, between and slightly above the eyebrows\n• 7th Chakra (Crown) — Located at the top of the head"
+      "concept": "O 6º e o 7º Chakras (Espaço Sagrado)",
+      "teachingText": "Compreender as localizações e funções dos chakras superiores é essencial para o trabalho do Nível 2:\n\n• 6º Chakra (Terceiro Olho) — Localizado no centro da testa, entre e ligeiramente acima das sobrancelhas\n• 7º Chakra (Coroa) — Localizado no topo da cabeça"
     },
     "l2-physical-space": {
-      "concept": "Let’s Prepare Your Physical Space",
-      "teachingText": "Before meditation, prepare your physical environment to support the energetic work. The external space should mirror the internal intention: clean, clear, quiet, and intentionally held."
+      "concept": "Vamos Preparar Seu Espaço Físico",
+      "teachingText": "Antes da meditação, prepare seu ambiente físico para apoiar o trabalho energético. O espaço externo deve espelhar a intenção interna: limpo, claro, silencioso e intencionalmente mantido."
     },
     "l2-protection-space": {
-      "concept": "Protection of the Space",
-      "teachingText": "The physical meditation space is protected by creating an energetic grid using roses. Golden roses are placed at the four corners (and above/below) of the space, connected by lines of golden energy forming a sacred geometric structure — a container for the work."
+      "concept": "Proteção do Espaço",
+      "teachingText": "O espaço físico de meditação é protegido pela criação de uma grade energética usando rosas. Rosas douradas são colocadas nos quatro cantos (e acima/abaixo) do espaço, conectadas por linhas de energia dourada formando uma estrutura geométrica sagrada — um recipiente para o trabalho."
     },
     "l2-cleansing-space": {
-      "concept": "Cleansing of the Space",
-      "teachingText": "Once the space is protected, it is cleansed. A large Cleansing Rose is placed above the grid, and golden energy pours downward through the entire structure, clearing all foreign, stagnant, or disruptive energies from the space."
+      "concept": "Limpeza do Espaço",
+      "teachingText": "Uma vez que o espaço está protegido, ele é limpo. Uma grande Rosa de Limpeza é colocada acima da grade, e a energia dourada flui para baixo por toda a estrutura, limpando todas as energias estranhas, estagnadas ou perturbadoras do espaço."
     },
     "l2-owning-space": {
-      "concept": "Owning Your Space",
-      "teachingText": "After protection and cleansing, you claim ownership of the space. This is an act of energetic sovereignty — declaring the space as yours, filling it with your own energy and intention. The space becomes an extension of your aura and your practice."
+      "concept": "Tomando Posse do Seu Espaço",
+      "teachingText": "Após a proteção e a limpeza, você toma posse do espaço. Este é um ato de soberania energética — declarando o espaço como seu, preenchendo-o com sua própria energia e intenção. O espaço se torna uma extensão da sua aura e da sua prática."
     },
     "l2-chakras-intro": {
-      "concept": "Let’s Talk About Chakras",
-      "teachingText": "The chakra system is the energetic anatomy of the human body. There are seven primary chakras, each governing specific aspects of physical, emotional, mental, and spiritual life."
+      "concept": "Vamos Falar Sobre Chakras",
+      "teachingText": "O sistema de chakras é a anatomia energética do corpo humano. Existem sete chakras primários, cada um governando aspectos específicos da vida física, emocional, mental e espiritual."
     },
     "l2-seven-chakras": {
-      "concept": "The Seven Chakras",
-      "teachingText": "The seven primary chakras, from crown to root:\n\n7. Crown — Top of head\n6. Third Eye — Center of forehead\n5. Throat — Throat\n4. Heart — Center of chest\n3. Solar Plexus — Upper abdomen\n2. Sacral — Lower abdomen\n1. Root — Base of spine"
+      "concept": "Os Sete Chakras",
+      "teachingText": "Os sete chakras primários, da coroa à raiz:\n\n7. Coroa — Topo da cabeça\n6. Terceiro Olho — Centro da testa\n5. Garganta — Garganta\n4. Coração — Centro do peito\n3. Plexo Solar — Abdômen superior\n2. Sacral — Abdômen inferior\n1. Raiz — Base da coluna"
     },
     "l2-cleansing-aura-layers": {
-      "concept": "Cleansing of Each Aura Layer",
-      "teachingText": "The aura is composed of seven layers, each corresponding to a chakra. In Level 2, each layer is individually cleansed from the outermost to the innermost:\n\n7. 7th Aura layer\n6. 6th Aura layer\n5. 5th Aura layer\n4. 4th Aura layer\n3. 3rd Aura layer\n2. 2nd Aura layer\n1. 1st Aura layer"
+      "concept": "Limpeza de Cada Camada da Aura",
+      "teachingText": "A aura é composta por sete camadas, cada uma correspondendo a um chakra. No Nível 2, cada camada é individualmente limpa da mais externa para a mais interna:\n\n7. 7ª camada da Aura\n6. 6ª camada da Aura\n5. 5ª camada da Aura\n4. 4ª camada da Aura\n3. 3ª camada da Aura\n2. 2ª camada da Aura\n1. 1ª camada da Aura"
     },
     "l2-cleansing-each-chakra": {
-      "concept": "Cleansing of Each Chakra",
-      "teachingText": "Each individual chakra is cleansed using roses. The roses address two dimensions:\n\n• Dynamics of the Past — Energetic patterns, imprints, and blockages carried from past experiences\n• Dynamics of the Present — Current energetic influences, relationships, and situations affecting the chakra"
+      "concept": "Limpeza de Cada Chakra",
+      "teachingText": "Cada chakra individual é limpo usando rosas. As rosas abordam duas dimensões:\n\n• Dinâmicas do Passado — Padrões energéticos, impressões e bloqueios carregados de experiências passadas\n• Dinâmicas do Presente — Influências energéticas atuais, relacionamentos e situações que afetam o chakra"
     },
     "l2-energy-recovery": {
-      "concept": "Energy Recovery of Each Chakra (Level 2)",
-      "teachingText": "After cleansing, the energy recovery process is repeated at a deeper level. The Rose is sent out to gather and return your own energy to each individual chakra, restoring sovereignty, vitality, and wholeness to each energy center."
+      "concept": "Recuperação Energética de Cada Chakra (Nível 2)",
+      "teachingText": "Após a limpeza, o processo de recuperação energética é repetido em um nível mais profundo. A Rosa é enviada para reunir e devolver sua própria energia a cada chakra individual, restaurando soberania, vitalidade e integridade a cada centro energético."
     },
     "l2-golden-sticky-1": {
-      "concept": "Golden Sticky Roses — Phase 1 (Chakra Placement)",
-      "teachingText": "Golden sticky roses are placed on each of the seven chakras, drawing out foreign energy lodged in the energy centers."
+      "concept": "Rosas Douradas Adesivas — Fase 1 (Colocação nos Chakras)",
+      "teachingText": "Rosas douradas adesivas são colocadas em cada um dos sete chakras, extraindo energia estranha alojada nos centros energéticos."
     },
     "l2-golden-sticky-2": {
-      "concept": "Golden Sticky Roses — Phase 2 (Body Placement)",
-      "teachingText": "Golden sticky roses are placed at the joints and extremities of the body — shoulders, elbows, wrists, hands, hips, knees, ankles, feet — drawing out foreign energy stored in the physical body."
+      "concept": "Rosas Douradas Adesivas — Fase 2 (Colocação no Corpo)",
+      "teachingText": "Rosas douradas adesivas são colocadas nas articulações e extremidades do corpo — ombros, cotovelos, pulsos, mãos, quadris, joelhos, tornozelos, pés — extraindo energia estranha armazenada no corpo físico."
     },
     "l2-golden-sticky-3": {
-      "concept": "Golden Sticky Roses — Phase 3 (Full Body Coverage)",
-      "teachingText": "Golden sticky roses are placed throughout the entire body — covering the torso, limbs, and all remaining areas — for a thorough, complete energetic cleansing."
+      "concept": "Rosas Douradas Adesivas — Fase 3 (Cobertura Total do Corpo)",
+      "teachingText": "Rosas douradas adesivas são colocadas por todo o corpo — cobrindo o tronco, membros e todas as áreas restantes — para uma limpeza energética completa e profunda."
     },
     "l2-golden-sticky-4": {
-      "concept": "Golden Sticky Roses — Phase 4 (Integration)",
-      "teachingText": "After the golden sticky roses have done their work, a large Golden Rose appears above the head. All foreign energy gathered by the sticky roses is released, and the entire body is bathed in golden light — restoring, sealing, and integrating the energy body."
+      "concept": "Rosas Douradas Adesivas — Fase 4 (Integração)",
+      "teachingText": "Depois que as rosas douradas adesivas realizaram seu trabalho, uma grande Rosa Dourada aparece acima da cabeça. Toda a energia estranha reunida pelas rosas adesivas é liberada, e todo o corpo é banhado em luz dourada — restaurando, selando e integrando o corpo energético."
     },
     "l3-analyzer": {
-      "concept": "The Analyzer",
-      "teachingText": "The Analyzer is an advanced tool introduced in Level 3. It is an energetic point located at the back of the head, at the base of the skull (the occipital ridge / brainstem area). The Analyzer is used for deeper perception, reading, and discernment of energy — a tool for precise energetic analysis."
+      "concept": "O Analisador",
+      "teachingText": "O Analisador é uma ferramenta avançada introduzida no Nível 3. É um ponto energético localizado na parte de trás da cabeça, na base do crânio (a crista occipital / área do tronco encefálico). O Analisador é usado para percepção mais profunda, leitura e discernimento de energia — uma ferramenta para análise energética precisa."
     }
   },
   "chakras": {
     "l2-chakra-root": {
-      "concept": "Root Chakra",
-      "teachingText": "Muladhara — Grounding & Safety",
-      "focus": "Stability — Safety — Embodiment",
-      "energy": "Masculine — Survival / Foundation",
-      "bodyLocation": "Base of spine, Legs, Feet",
+      "concept": "Chakra Raiz",
+      "teachingText": "Muladhara — Enraizamento e Segurança",
+      "focus": "Estabilidade — Segurança — Corporificação",
+      "energy": "Masculino — Sobrevivência / Fundação",
+      "bodyLocation": "Base da coluna, Pernas, Pés",
       "balanced": [
-        "Grounded presence",
-        "Physical vitality",
-        "Trust in life",
-        "Feeling safe in the body"
+        "Presença enraizada",
+        "Vitalidade física",
+        "Confiança na vida",
+        "Sentir-se seguro no corpo"
       ],
       "unbalanced": [
-        "Fear and insecurity",
-        "Survival anxiety",
-        "Disconnection from body",
-        "Scarcity mindset"
+        "Medo e insegurança",
+        "Ansiedade de sobrevivência",
+        "Desconexão do corpo",
+        "Mentalidade de escassez"
       ],
-      "blockages": "Fear — Insecurity — Survival Trauma"
+      "blockages": "Medo — Insegurança — Trauma de Sobrevivência"
     },
     "l2-chakra-sacral": {
-      "concept": "Sacral Chakra",
-      "teachingText": "Svadhisthana — Emotion & Creativity",
-      "focus": "Emotions — Creativity — Pleasure",
-      "energy": "Feminine — Flow & Flexibility",
-      "bodyLocation": "Lower abdomen, Sexual Organs",
+      "concept": "Chakra Sacral",
+      "teachingText": "Svadhisthana — Emoção e Criatividade",
+      "focus": "Emoções — Criatividade — Prazer",
+      "energy": "Feminino — Fluxo e Flexibilidade",
+      "bodyLocation": "Abdômen inferior, Órgãos Sexuais",
       "balanced": [
-        "Emotional well-being",
-        "Sensuality and intimacy",
-        "Passion and pleasure",
-        "Adaptability"
+        "Bem-estar emocional",
+        "Sensualidade e intimidade",
+        "Paixão e prazer",
+        "Adaptabilidade"
       ],
       "unbalanced": [
-        "Depression and numbness",
-        "Sexual dysfunction",
-        "Emotional instability",
-        "Fear of change"
+        "Depressão e entorpecimento",
+        "Disfunção sexual",
+        "Instabilidade emocional",
+        "Medo de mudança"
       ],
-      "blockages": "Shame — Emotional Repression — Guilt"
+      "blockages": "Vergonha — Repressão Emocional — Culpa"
     },
     "l2-chakra-solar-plexus": {
-      "concept": "Solar Plexus Chakra",
-      "teachingText": "Manipura — Willpower & Confidence",
-      "focus": "Personal Power — Self-Esteem — Drive",
-      "energy": "Masculine — Power & Transformation",
-      "bodyLocation": "Upper abdomen, Diaphragm",
+      "concept": "Chakra do Plexo Solar",
+      "teachingText": "Manipura — Força de Vontade e Confiança",
+      "focus": "Poder Pessoal — Autoestima — Determinação",
+      "energy": "Masculino — Poder e Transformação",
+      "bodyLocation": "Abdômen superior, Diafragma",
       "balanced": [
-        "Confidence and motivation",
-        "Responsible and disciplined",
-        "Healthy sense of self",
-        "Autonomy"
+        "Confiança e motivação",
+        "Responsável e disciplinado",
+        "Senso saudável de si",
+        "Autonomia"
       ],
       "unbalanced": [
-        "Low self-esteem",
-        "Aggression or controlling",
-        "Stubborn and domineering",
-        "Lack of direction or purpose"
+        "Baixa autoestima",
+        "Agressividade ou controle",
+        "Teimoso e dominador",
+        "Falta de direção ou propósito"
       ],
-      "blockages": "Self-Doubt — Insecurity — Fear of Rejection"
+      "blockages": "Autodúvida — Insegurança — Medo de Rejeição"
     },
     "l2-chakra-heart": {
-      "concept": "Heart Chakra",
-      "teachingText": "Anahata — Love & Integration",
-      "focus": "Love — Compassion — Connection",
-      "energy": "Bridge between physical & spiritual",
-      "bodyLocation": "Center of chest, Heart, Lungs",
+      "concept": "Chakra do Coração",
+      "teachingText": "Anahata — Amor e Integração",
+      "focus": "Amor — Compaixão — Conexão",
+      "energy": "Ponte entre o físico e o espiritual",
+      "bodyLocation": "Centro do peito, Coração, Pulmões",
       "balanced": [
-        "Compassion and empathy",
-        "Emotional openness",
-        "Forgiveness",
-        "Healthy intimacy and self-love"
+        "Compaixão e empatia",
+        "Abertura emocional",
+        "Perdão",
+        "Intimidade saudável e amor-próprio"
       ],
       "unbalanced": [
-        "Emotional withdrawal or over-giving",
-        "Fear of intimacy",
-        "Cold or detachment",
-        "Difficulty forgiving"
+        "Retraimento emocional ou doação excessiva",
+        "Medo de intimidade",
+        "Frieza ou distanciamento",
+        "Dificuldade em perdoar"
       ],
-      "blockages": "Grief — Betrayal — Heartbreak",
-      "extraContent": "Human Love & Spiritual Love:\n\nHuman Love — Statement: I LOVE — Empathy, compassion, forgiveness, healthy relationships, romantic and familial love.\n\nSpiritual Love — Statement: I AM LOVE — Unconditional compassion, interconnectedness, divine and universal love, oneness."
+      "blockages": "Luto — Traição — Coração Partido",
+      "extraContent": "Amor Humano e Amor Espiritual:\n\nAmor Humano — Declaração: EU AMO — Empatia, compaixão, perdão, relacionamentos saudáveis, amor romântico e familiar.\n\nAmor Espiritual — Declaração: EU SOU AMOR — Compaixão incondicional, interconectividade, amor divino e universal, unidade."
     },
     "l2-chakra-throat": {
-      "concept": "Throat Chakra",
-      "teachingText": "Vishuddha — Communication & Expression",
-      "focus": "Communication — Truth — Authenticity",
-      "energy": "Learning to align will with divine truth",
-      "bodyLocation": "Throat, Neck, Jaw, Mouth",
+      "concept": "Chakra da Garganta",
+      "teachingText": "Vishuddha — Comunicação e Expressão",
+      "focus": "Comunicação — Verdade — Autenticidade",
+      "energy": "Aprendendo a alinhar a vontade com a verdade divina",
+      "bodyLocation": "Garganta, Pescoço, Mandíbula, Boca",
       "balanced": [
-        "Clear, honest communication",
-        "Authentic self-expression",
-        "Good listener",
-        "Strong voice and balanced speech"
+        "Comunicação clara e honesta",
+        "Autoexpressão autêntica",
+        "Bom ouvinte",
+        "Voz forte e fala equilibrada"
       ],
       "unbalanced": [
-        "Fear of speaking up",
-        "Being unheard or misunderstood",
-        "People-pleasing",
-        "Suppressed feelings or lies"
+        "Medo de se expressar",
+        "Não ser ouvido ou ser mal compreendido",
+        "Agradar aos outros",
+        "Sentimentos reprimidos ou mentiras"
       ],
-      "blockages": "Suppressed Truth — Fear of Expression — Miscommunication"
+      "blockages": "Verdade Reprimida — Medo de Expressão — Falha de Comunicação"
     },
     "l2-chakra-third-eye": {
-      "concept": "Third Eye Chakra",
-      "teachingText": "Ajna — Intuition & Insight",
-      "focus": "Imagination — Perception — Visualization",
-      "energy": "Feminine aspects of awareness",
-      "bodyLocation": "Forehead, Brow, Eye center",
+      "concept": "Chakra do Terceiro Olho",
+      "teachingText": "Ajna — Intuição e Percepção",
+      "focus": "Imaginação — Percepção — Visualização",
+      "energy": "Aspectos femininos da consciência",
+      "bodyLocation": "Testa, Sobrancelha, Centro do olho",
       "balanced": [
-        "Clear seeing and intuition",
-        "Good memory and imagination",
-        "Inner location",
-        "Wisdom and vision"
+        "Visão clara e intuição",
+        "Boa memória e imaginação",
+        "Localização interior",
+        "Sabedoria e visão"
       ],
       "unbalanced": [
-        "Overthinking",
-        "Mental fog",
-        "Disconnection with inner guidance",
-        "Escaping reality or spiritual bypassing"
+        "Pensamento excessivo",
+        "Nevoeiro mental",
+        "Desconexão com a orientação interior",
+        "Fuga da realidade ou desvio espiritual"
       ],
-      "blockages": "Suppressed Truth — Fear of Expression — Miscommunication"
+      "blockages": "Verdade Reprimida — Medo de Expressão — Falha de Comunicação"
     },
     "l2-chakra-crown": {
-      "concept": "Crown Chakra",
-      "teachingText": "Sahasrara — Spirituality & Consciousness",
-      "focus": "Spiritual Connection — Inner Wisdom — Higher States of Awareness",
-      "energy": "Transcending ego, merging with source",
-      "bodyLocation": "Top of head",
+      "concept": "Chakra da Coroa",
+      "teachingText": "Sahasrara — Espiritualidade e Consciência",
+      "focus": "Conexão Espiritual — Sabedoria Interior — Estados Superiores de Consciência",
+      "energy": "Transcendendo o ego, fundindo-se com a fonte",
+      "bodyLocation": "Topo da cabeça",
       "balanced": [
-        "Spiritual faith and connection",
-        "Inner peace, trust, and wisdom",
-        "Openness and awareness",
-        "Sense of life purpose"
+        "Fé e conexão espiritual",
+        "Paz interior, confiança e sabedoria",
+        "Abertura e consciência",
+        "Senso de propósito de vida"
       ],
       "unbalanced": [
-        "Spiritual emptiness",
-        "Existential doubt",
-        "Feeling isolated or alone",
-        "Lack of purpose"
+        "Vazio espiritual",
+        "Dúvida existencial",
+        "Sentir-se isolado ou sozinho",
+        "Falta de propósito"
       ],
-      "blockages": "Disconnection — Cynicism — Loss of Meaning"
+      "blockages": "Desconexão — Cinismo — Perda de Significado"
     }
   },
-  "_translationStatus": "pending",
-  "_note": "This file contains English text as placeholder. All values need to be translated to the target language."
+  "_translationStatus": "complete"
 }


### PR DESCRIPTION
…ontent

Replace English placeholder text in pt.json, es.json, and el.json with full translations so the language selector on the mDR teaching pages becomes functional. Portuguese uses Brazilian Portuguese (pt-BR) given the lineage through Angelina Ataide. All ~2,000 words per file translated including UI labels, opening sections, level descriptions, 28 teaching slides, and 7 chakra details.

https://claude.ai/code/session_01GMgzQodYyczepe2SFLfbQw