### PR TITLE
Add reimaginedImage property to Rose teaching slide

### DIFF
--- a/src/lib/data/teaching-slides.ts
+++ b/src/lib/data/teaching-slides.ts
@@ -177,6 +177,7 @@ export const level1Slides: TeachingSlide[] = [
     teachingText:
       'The Rose is used as a living energetic instrument throughout the practice. It has roots (connection to source), a stem (channel of energy), and a bloom (the active, radiant tool). The Rose can be placed, moved, opened, closed, and released according to the needs of the meditation.',
     originalImage: '14-Therosegold.PNG',
+    reimaginedImage: '14-Therosegold.PNG',
     level: 1,
     section: 'foundations',
   },


### PR DESCRIPTION
## Summary
Added the `reimaginedImage` property to the Rose (level 1, foundations section) teaching slide to support displaying an alternative version of the slide image.

## Changes
- Added `reimaginedImage: '14-Therosegold.PNG'` to the Rose teaching slide configuration
- The reimagined image currently references the same image file as the original, allowing for future updates to point to a different asset if needed

## Details
This change ensures the Rose slide has parity with other teaching slides that include both `originalImage` and `reimaginedImage` properties, enabling consistent image handling across the teaching slides system.

https://claude.ai/code/session_01KvXnSWMjfkVRsM6Rvd4cRY