### PR TITLE
Update meditation posture slide image assets

### DIFF
--- a/src/lib/data/teaching-slides.ts
+++ b/src/lib/data/teaching-slides.ts
@@ -60,8 +60,7 @@ export const level1Slides: TeachingSlide[] = [
     concept: 'Meditation Posture',
     teachingText:
       'Proper meditation posture is seated upright in a chair. Feet are flat on the floor, hands resting gently on the thighs or knees, spine upright, eyes closed. The body is relaxed yet alert — grounded and receptive.',
-    originalImage: '6-posture-original.PNG',
-    reimaginedImage: '6-posture.PNG',
+    reimaginedImage: 'Posturefinal.PNG',
     level: 1,
     section: 'foundations',
   },


### PR DESCRIPTION
## Summary
Updated the meditation posture teaching slide to use a single consolidated image asset instead of maintaining separate original and reimagined versions.

## Changes
- Removed `originalImage` property from the posture slide (was referencing '6-posture-original.PNG')
- Updated `reimaginedImage` to use 'Posturefinal.PNG' as the sole image asset
- Simplified the slide configuration by eliminating the dual-image approach for this particular teaching slide

## Details
This change streamlines the posture slide by consolidating to a single image file, reducing asset duplication and simplifying the slide data structure while maintaining the teaching content and functionality.

https://claude.ai/code/session_01GG4qq2H6JAk27W6TDpBjak