### PR TITLE
Fix Cleansing Rose image filename in teaching slides

### DIFF
--- a/src/lib/data/teaching-slides.ts
+++ b/src/lib/data/teaching-slides.ts
@@ -186,7 +186,7 @@ export const level1Slides: TeachingSlide[] = [
     concept: 'Cleansing Rose',
     teachingText:
       'The Cleansing Rose is placed outside of the aura. It is used to absorb and transmute foreign or stagnant energy from within your field. Energy that does not belong to you — from other people, environments, or experiences — is drawn out of the aura and into the Cleansing Rose, where it is neutralized.',
-    originalImage: '16-cleansingrose-original.PNG',
+    originalImage: '16-cleansing rose .PNG',
     imageNote: 'Reimagined version needs to be created.',
     level: 1,
     section: 'foundations',


### PR DESCRIPTION
## Summary
Updated the image filename reference for the Cleansing Rose teaching slide to match the actual asset filename.

## Changes
- Changed `originalImage` filename from `'16-cleansingrose-original.PNG'` to `'16-cleansing rose .PNG'` in the level 1 teaching slides data

## Details
This change corrects a filename mismatch in the teaching slides configuration. The image reference now points to the correct asset file with the proper spacing and naming convention.

https://claude.ai/code/session_01HGgkGoNVpJJNrPq9HojbCH