### PR TITLE
Split manual download button into view and download actions

### DIFF
--- a/src/app/(teaching)/teaching/level-1/page.tsx
+++ b/src/app/(teaching)/teaching/level-1/page.tsx
@@ -52,7 +52,7 @@ export default function Level1Page() {
                 <PdfExportButton />
                 <ManualDownloadButton
                   href="/resources/manuals/ROSES-OS-Level-1-Manual-EN.pdf"
-                  label="Download Manual (Level 1)"
+                  label="Manual (Level 1)"
                 />
                 <ImageDownloadButton slides={level1Slides} level={1} />
                 <LanguageSelector />

--- a/src/app/(teaching)/teaching/level-2/page.tsx
+++ b/src/app/(teaching)/teaching/level-2/page.tsx
@@ -58,7 +58,7 @@ export default function Level2Page() {
                 <PdfExportButton />
                 <ManualDownloadButton
                   href="/resources/manuals/ROSES-OS-Level-2-Manual-EN.pdf"
-                  label="Download Manual (Level 2)"
+                  label="Manual (Level 2)"
                 />
                 <ImageDownloadButton slides={[...level2Slides, ...chakraSlides, ...level2CleansingSlides]} level={2} />
                 <LanguageSelector />

--- a/src/app/(teaching)/teaching/level-3/page.tsx
+++ b/src/app/(teaching)/teaching/level-3/page.tsx
@@ -52,7 +52,7 @@ export default function Level3Page() {
                 <PdfExportButton />
                 <ManualDownloadButton
                   href="/resources/manuals/ROSES-OS-Level-3-Manual-EN.pdf"
-                  label="Download Manual (Level 3)"
+                  label="Manual (Level 3)"
                 />
                 <ImageDownloadButton slides={level3Slides} level={3} />
                 <LanguageSelector />

--- a/src/components/teaching/ManualDownloadButton.tsx
+++ b/src/components/teaching/ManualDownloadButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FileDown } from 'lucide-react';
+import { BookOpen, Download } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ManualDownloadButtonProps {
@@ -17,26 +17,42 @@ export function ManualDownloadButton({
   className,
 }: ManualDownloadButtonProps) {
   return (
-    <a
-      href={href}
-      download
-      className={cn(
-        'inline-flex items-center gap-2 rounded-xl px-6 py-3 font-medium',
-        'bg-[var(--color-background-subtle)] text-[var(--color-foreground)]',
-        'border border-[var(--color-border)]',
-        'hover:bg-[var(--color-background-muted)]',
-        'transition-all duration-200',
-        'print:hidden',
-        'text-sm',
-        className,
-      )}
-    >
-      {coverImage ? (
-        <img src={coverImage} alt="" className="h-8 w-auto rounded-sm object-cover" />
-      ) : (
-        <FileDown className="h-4 w-4" />
-      )}
-      <span>{label}</span>
-    </a>
+    <div className={cn('inline-flex items-center gap-2 print:hidden', className)}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          'inline-flex items-center gap-2 rounded-xl px-6 py-3 font-medium',
+          'bg-[var(--color-background-subtle)] text-[var(--color-foreground)]',
+          'border border-[var(--color-border)]',
+          'hover:bg-[var(--color-background-muted)]',
+          'transition-all duration-200',
+          'text-sm',
+        )}
+      >
+        {coverImage ? (
+          <img src={coverImage} alt="" className="h-8 w-auto rounded-sm object-cover" />
+        ) : (
+          <BookOpen className="h-4 w-4" />
+        )}
+        <span>View {label}</span>
+      </a>
+      <a
+        href={href}
+        download
+        className={cn(
+          'inline-flex items-center justify-center rounded-xl p-3',
+          'bg-[var(--color-background-subtle)] text-[var(--color-foreground)]',
+          'border border-[var(--color-border)]',
+          'hover:bg-[var(--color-background-muted)]',
+          'transition-all duration-200',
+          'text-sm',
+        )}
+        title="Download PDF"
+      >
+        <Download className="h-4 w-4" />
+      </a>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Refactored the `ManualDownloadButton` component to provide separate "View" and "Download" actions instead of a single combined button, improving user experience and clarity of intent.

## Key Changes
- **Component restructuring**: Split the single download button into two distinct actions:
  - A "View" button that opens the PDF in a new tab (`target="_blank"`)
  - A "Download" button that triggers a file download
- **Icon updates**: Changed from `FileDown` to `BookOpen` for the view action and added `Download` icon for the download action
- **Label updates**: Updated manual labels across all teaching levels (Level 1, 2, 3) from "Download Manual (Level X)" to "Manual (Level X)" to reflect the new dual-action pattern
- **Layout changes**: Wrapped both buttons in a container div to keep them grouped together
- **Accessibility improvements**: Added `title="Download PDF"` attribute to the download button for better UX clarity

## Implementation Details
- The component now renders as a flex container with two anchor elements side-by-side
- The view button maintains the original styling with label text
- The download button is icon-only with consistent styling
- Both buttons share the same href but have different behaviors (target="_blank" vs download attribute)
- The `print:hidden` class was moved to the wrapper div to hide both actions during printing

https://claude.ai/code/session_01LmycDSqVE5SCUgKh5cyYAB