### PR TITLE
Update teaching slide images for grounding cord and golden sun

### DIFF
--- a/src/lib/data/teaching-slides.ts
+++ b/src/lib/data/teaching-slides.ts
@@ -70,7 +70,7 @@ export const level1Slides: TeachingSlide[] = [
     concept: 'Grounding Cord',
     teachingText:
       'The grounding cord is an energetic connection that extends from the base of the spine (first chakra) downward into the center of the Earth. It anchors your energy body to the planet, providing stability, safety, and a channel for releasing unwanted energy.',
-    reimaginedImage: 'GroundingCordFinal.JPG',
+    reimaginedImage: 'IMG_1817.jpeg',
     imageNote:
       'The original grounding cord (see slide 10 original: 10-grounding-cord-expansion-original .PNG) is more accurate than the reimagined version. New designs should reflect the original\'s depiction. The grounding cord should be more opaque/transparent, thick and strong, and less gold.',
     level: 1,
@@ -82,7 +82,7 @@ export const level1Slides: TeachingSlide[] = [
     concept: 'Golden Sun',
     teachingText:
       'The Golden Sun is a tool for replenishing and restoring your own energy. Visualize a radiant golden sun above your head. It calls back your own life-force energy from wherever you may have left it — in people, places, situations, or time. It fills you with your own highest vibration.',
-    reimaginedImage: 'Golden sun.jpg',
+    reimaginedImage: 'IMG_1818.jpeg',
     imageNote:
       'The grounding cord in this image should be thick, transparent, and strong — and should start lower in the body, under the crotch, as it comes from the base of the spine (1st chakra). Currently it appears too high and too golden.',
     level: 1,


### PR DESCRIPTION
## Summary
Updated image references in the teaching slides data to use new image files for the grounding cord and golden sun concepts.

## Changes
- Updated grounding cord slide image from `GroundingCordFinal.JPG` to `IMG_1817.jpeg`
- Updated golden sun slide image from `Golden sun.jpg` to `IMG_1818.jpeg`

## Details
These image updates reflect new versions of the teaching visualizations for level 1 slides. The existing image notes indicate that these new designs should better align with the original depictions, particularly regarding the grounding cord's appearance (more opaque/transparent, thicker, stronger, and less golden) and positioning in the golden sun visualization.

https://claude.ai/code/session_01Bp378FtmDqyc6UgbbvRQte