### PR TITLE
Remove confidentiality notice from manual cover pages

### DIFF
--- a/scripts/generate-manual-pdfs.py
+++ b/scripts/generate-manual-pdfs.py
@@ -402,7 +402,7 @@ LEVEL_2_HTML = """<!DOCTYPE html>
   <p class="cover-subtitle">Sacred Space, Chakra Cleansing &amp; Energy Recovery</p>
   <div class="cover-divider"></div>
   <p class="cover-brand">ROSES OS</p>
-  <p class="cover-note">Teachings by Angelina Ataíde. This manual is for initiated students only. Please do not share this information.</p>
+  <p class="cover-note">Teachings by Angelina Ataíde</p>
 </div>
 
 <!-- COPYRIGHT -->
@@ -632,7 +632,7 @@ LEVEL_3_HTML = """<!DOCTYPE html>
   <p class="cover-subtitle">Advanced Perception, The Analyzer &amp; Creating Reality</p>
   <div class="cover-divider"></div>
   <p class="cover-brand">ROSES OS</p>
-  <p class="cover-note">Teachings by Angelina Ataíde. This manual is for initiated students only. Please do not share this information.</p>
+  <p class="cover-note">Teachings by Angelina Ataíde</p>
 </div>
 
 <!-- COPYRIGHT -->


### PR DESCRIPTION
## Summary
This change removes the confidentiality notice from the cover pages of two ROSES OS manuals, simplifying the cover note to only credit the teachings author.

## Changes Made
- Removed "This manual is for initiated students only. Please do not share this information." from the cover note on the Sacred Space manual (line 405)
- Removed the same confidentiality notice from the cover note on the Advanced Perception manual (line 635)
- Both cover notes now read simply "Teachings by Angelina Ataíde"

## Details
The confidentiality disclaimers have been stripped from both manual cover pages while retaining the author attribution. This appears to be a policy change regarding the distribution and sharing of these materials.

https://claude.ai/code/session_01P4ox1XqGCWpznPMSWBmwEr