### PR TITLE
Improve clarity of manual and PDF export button labels

### DIFF
--- a/src/app/(teaching)/teaching/level-1/page.tsx
+++ b/src/app/(teaching)/teaching/level-1/page.tsx
@@ -55,7 +55,7 @@ export default function Level1Page() {
                 <PdfExportButton />
                 <ManualDownloadButton
                   href="/resources/manuals/ROSES-OS-Level-1-Manual-EN.pdf"
-                  label="Manual (Level 1)"
+                  label="Student Manual"
                 />
                 <ImageDownloadButton slides={level1Slides} level={1} />
                 <LanguageSelector />

--- a/src/app/(teaching)/teaching/level-2/page.tsx
+++ b/src/app/(teaching)/teaching/level-2/page.tsx
@@ -58,7 +58,7 @@ export default function Level2Page() {
                 <PdfExportButton />
                 <ManualDownloadButton
                   href="/resources/manuals/ROSES-OS-Level-2-Manual-EN.pdf"
-                  label="Manual (Level 2)"
+                  label="Student Manual"
                 />
                 <ImageDownloadButton slides={[...level2Slides, ...chakraSlides, ...level2CleansingSlides]} level={2} />
                 <LanguageSelector />

--- a/src/app/(teaching)/teaching/level-3/page.tsx
+++ b/src/app/(teaching)/teaching/level-3/page.tsx
@@ -52,7 +52,7 @@ export default function Level3Page() {
                 <PdfExportButton />
                 <ManualDownloadButton
                   href="/resources/manuals/ROSES-OS-Level-3-Manual-EN.pdf"
-                  label="Manual (Level 3)"
+                  label="Student Manual"
                 />
                 <ImageDownloadButton slides={level3Slides} level={3} />
                 <LanguageSelector />

--- a/src/components/teaching/ManualDownloadButton.tsx
+++ b/src/components/teaching/ManualDownloadButton.tsx
@@ -36,7 +36,7 @@ export function ManualDownloadButton({
         ) : (
           <BookOpen className="h-4 w-4" />
         )}
-        <span>View {label}</span>
+        <span>Download the {label}</span>
       </a>
       <a
         href={href}
@@ -49,7 +49,7 @@ export function ManualDownloadButton({
           'transition-all duration-200',
           'text-sm',
         )}
-        title="Download PDF"
+        title="Download the Student Manual"
       >
         <Download className="h-4 w-4" />
       </a>

--- a/src/components/teaching/ManualPdfButton.tsx
+++ b/src/components/teaching/ManualPdfButton.tsx
@@ -19,7 +19,7 @@ export default function ManualPdfButton({
 }: ManualPdfButtonProps) {
   const { locale } = useLanguage();
   const href = paths[locale] ?? paths.en;
-  const label = labels[locale] ?? labels.en ?? 'Manual (PDF)';
+  const label = labels[locale] ?? labels.en ?? 'Student Manual';
 
   if (!href) return null;
 
@@ -54,7 +54,7 @@ export default function ManualPdfButton({
           'hover:bg-[var(--color-background-muted)]',
           'transition-all duration-200',
         )}
-        title="Download PDF"
+        title="Download the Student Manual"
       >
         <Download className="h-4 w-4" />
       </motion.a>

--- a/src/components/ui/PdfExportButton.tsx
+++ b/src/components/ui/PdfExportButton.tsx
@@ -30,7 +30,7 @@ export function PdfExportButton({ className }: PdfExportButtonProps) {
       )}
     >
       <FileDown className="h-4 w-4" />
-      <span>Export PDF</span>
+      <span>Export Teachers Aid PDF</span>
     </motion.button>
   );
 }

--- a/src/content/teaching/en.json
+++ b/src/content/teaching/en.json
@@ -7,7 +7,7 @@
     "level": "Level",
     "slide": "Slide",
     "designerNote": "Designer note",
-    "downloadPdf": "Download PDF",
+    "downloadPdf": "Download the Student Manual",
     "sacredSpace": "Sacred Space",
     "theChakraSystem": "The Chakra System",
     "cleansingAndRecovery": "Cleansing & Recovery",


### PR DESCRIPTION
## Summary
Updated button labels and tooltips throughout the teaching interface to use more descriptive and consistent terminology. Changed generic "Manual" and "PDF" references to "Student Manual" and clarified the purpose of export functionality.

## Key Changes
- Standardized manual download button labels to "Student Manual" across all teaching levels (Level 1, 2, and 3)
- Updated button text from "View {label}" to "Download the {label}" for better clarity on the action being performed
- Changed PDF export button label from "Export PDF" to "Export Teachers Aid PDF" to distinguish it from student manual downloads
- Updated tooltip text from "Download PDF" to "Download the Student Manual" for consistency
- Updated default fallback label in ManualPdfButton component from "Manual (PDF)" to "Student Manual"
- Updated content translation key in en.json from "downloadPdf" to use "Download the Student Manual"

## Implementation Details
- Changes maintain backward compatibility with existing href paths
- All modifications preserve the existing component structure and functionality
- Tooltip and label updates improve user experience by clarifying the distinction between teacher export functionality and student manual downloads

https://claude.ai/code/session_01WVuTxScZcJBRsbNFqn8E7y