### PR TITLE
Update April community program session with new date and instructor

### DIFF
--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -579,7 +579,7 @@ export const freePrograms: CommunityProgram[] = [
             month: 'April',
             sessions: [
               { date: 'Sun, Apr 5 — Jennifer', time: { sanJose: '9:00 AM', bogota: '10:00 AM', newYork: '11:00 AM', brasilia: '12:00 PM', london: '4:00 PM', madrid: '5:00 PM' } },
-              { date: 'Sat, Apr 18 — Silvia C', time: { sanJose: '7:00 AM', bogota: '8:00 AM', newYork: '9:00 AM', brasilia: '10:00 AM', london: '2:00 PM', madrid: '3:00 PM' } },
+              { date: 'Mon, Apr 13 — Júlia', time: { sanJose: '8:00 AM', bogota: '9:00 AM', newYork: '10:00 AM', brasilia: '11:00 AM', london: '3:00 PM', madrid: '4:00 PM' } },
               { date: 'Sun, Apr 19 — Jennifer', time: { sanJose: '9:00 AM', bogota: '10:00 AM', newYork: '11:00 AM', brasilia: '12:00 PM', london: '4:00 PM', madrid: '5:00 PM' } },
               { date: 'Mon, Apr 27 — Dara', time: { sanJose: '7:00 AM', bogota: '8:00 AM', newYork: '9:00 AM', brasilia: '10:00 AM', london: '2:00 PM', madrid: '3:00 PM' } },
             ],


### PR DESCRIPTION
## Summary
Updated the mock data for the free community programs to reflect a scheduling change for one of the April sessions.

## Changes Made
- Replaced the April 18 session led by Silvia C with a new April 13 session led by Júlia
- Updated all timezone-specific times for the new session:
  - San Jose: 8:00 AM
  - Bogota: 9:00 AM
  - New York: 10:00 AM
  - Brasilia: 11:00 AM
  - London: 3:00 PM
  - Madrid: 4:00 PM

## Details
This change moves the session earlier in the month (from April 18 to April 13) and adjusts the start time one hour later than the original session, with a different instructor assigned.

https://claude.ai/code/session_01TLGGy8kSPt62E5Lz93zMvF