### PR TITLE
Remove separate download button from manual components

### DIFF
--- a/src/components/teaching/ManualDownloadButton.tsx
+++ b/src/components/teaching/ManualDownloadButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BookOpen, Download } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ManualDownloadButtonProps {
@@ -17,42 +17,26 @@ export function ManualDownloadButton({
   className,
 }: ManualDownloadButtonProps) {
   return (
-    <div className={cn('inline-flex items-center gap-2 print:hidden', className)}>
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cn(
-          'inline-flex items-center gap-2 rounded-xl px-6 py-3 font-medium',
-          'bg-[var(--color-background-subtle)] text-[var(--color-foreground)]',
-          'border border-[var(--color-border)]',
-          'hover:bg-[var(--color-background-muted)]',
-          'transition-all duration-200',
-          'text-sm',
-        )}
-      >
-        {coverImage ? (
-          <img src={coverImage} alt="" className="h-8 w-auto rounded-sm object-cover" />
-        ) : (
-          <BookOpen className="h-4 w-4" />
-        )}
-        <span>Download the {label}</span>
-      </a>
-      <a
-        href={href}
-        download
-        className={cn(
-          'inline-flex items-center justify-center rounded-xl p-3',
-          'bg-[var(--color-background-subtle)] text-[var(--color-foreground)]',
-          'border border-[var(--color-border)]',
-          'hover:bg-[var(--color-background-muted)]',
-          'transition-all duration-200',
-          'text-sm',
-        )}
-        title="Download the Student Manual"
-      >
-        <Download className="h-4 w-4" />
-      </a>
-    </div>
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        'inline-flex items-center gap-2 rounded-xl px-6 py-3 font-medium print:hidden',
+        'bg-[var(--color-background-subtle)] text-[var(--color-foreground)]',
+        'border border-[var(--color-border)]',
+        'hover:bg-[var(--color-background-muted)]',
+        'transition-all duration-200',
+        'text-sm',
+        className,
+      )}
+    >
+      {coverImage ? (
+        <img src={coverImage} alt="" className="h-8 w-auto rounded-sm object-cover" />
+      ) : (
+        <BookOpen className="h-4 w-4" />
+      )}
+      <span>Download the {label}</span>
+    </a>
   );
 }

--- a/src/components/teaching/ManualPdfButton.tsx
+++ b/src/components/teaching/ManualPdfButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { BookOpen, Download } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useLanguage } from '@/lib/i18n';
 import type { Locale } from '@/lib/i18n/types';
@@ -41,22 +41,6 @@ export default function ManualPdfButton({
       >
         <BookOpen className="h-4 w-4" />
         <span>{label}</span>
-      </motion.a>
-      <motion.a
-        href={href}
-        download
-        whileHover={{ scale: 1.02 }}
-        whileTap={{ scale: 0.98 }}
-        className={cn(
-          'inline-flex items-center justify-center rounded-xl p-3',
-          'bg-[var(--color-background-subtle)] text-[var(--color-foreground)]',
-          'border border-[var(--color-border)]',
-          'hover:bg-[var(--color-background-muted)]',
-          'transition-all duration-200',
-        )}
-        title="Download the Student Manual"
-      >
-        <Download className="h-4 w-4" />
       </motion.a>
     </div>
   );


### PR DESCRIPTION
## Summary
Simplified the manual download UI by removing the separate download icon button and consolidating functionality into a single link button in both `ManualDownloadButton` and `ManualPdfButton` components.

## Key Changes
- **ManualDownloadButton.tsx**: Removed the dual-button layout (link + download button) and replaced it with a single anchor element that opens the manual in a new tab
- **ManualPdfButton.tsx**: Removed the separate download button with download icon, keeping only the main manual link button
- Removed unused `Download` icon imports from lucide-react in both components
- Simplified component structure by eliminating the wrapper div in ManualDownloadButton

## Implementation Details
- The primary link now handles all interactions (opens in new tab with `target="_blank"`)
- Maintained all existing styling and hover states
- Kept the cover image or BookOpen icon display logic intact
- The `print:hidden` class is now applied directly to the anchor element instead of a wrapper div
- Both components now have a cleaner, more straightforward single-button interface

https://claude.ai/code/session_01ESZZJ3YKvz85VuXfUpNAfL