### PR TITLE
Move PaidProgramsDownloadButton above paid programs list

### DIFF
--- a/src/app/(site)/offerings/OfferingsClient.tsx
+++ b/src/app/(site)/offerings/OfferingsClient.tsx
@@ -477,6 +477,12 @@ function OfferingsContent() {
             practice, mentorship, and the opportunity to embody and share this
             work at a deeper level.
           </motion.p>
+
+          {/* Download Additional Programs Guide */}
+          <div className="flex justify-center pt-2 pb-8 print:hidden">
+            <PaidProgramsDownloadButton variant="light" />
+          </div>
+
           <div className="space-y-4">
             {paidPrograms.map((program, i) => {
               const isExpanded = expandedProgramId === program.id;
@@ -667,10 +673,6 @@ function OfferingsContent() {
             })}
           </div>
 
-          {/* Download Additional Programs Guide */}
-          <div className="flex justify-center pt-8 print:hidden">
-            <PaidProgramsDownloadButton variant="light" />
-          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
Relocated the "Download Additional Programs Guide" button to appear before the paid programs list instead of after it, improving the visual flow and information hierarchy of the offerings page.

## Changes
- Moved `PaidProgramsDownloadButton` component from the bottom of the paid programs section (after the programs list) to the top (before the programs list)
- Adjusted spacing: changed from `pt-8` to `pt-2 pb-8` to maintain appropriate padding in the new location
- The button remains hidden during print (`print:hidden` class preserved)

## Details
This repositioning allows users to discover and access the additional programs guide before viewing the individual program details, creating a more intuitive user experience for the offerings page.

https://claude.ai/code/session_011VHy9aaiYkiQB41UE3k6wy