### PR TITLE
Reorder navigation menu items for improved UX

### DIFF
--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -26,10 +26,10 @@ interface NavigationProps {
 }
 
 const defaultItems: NavItem[] = [
-  { label: 'The Rose', href: '/the-rose' },
   { label: 'Offerings', href: '/offerings' },
-  { label: 'Guardians', href: '/guardians' },
   { label: 'Community', href: '/community' },
+  { label: 'The Rose', href: '/the-rose' },
+  { label: 'Guardians', href: '/guardians' },
   { label: 'Contact', href: '/contact' },
 ];
 

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -16,10 +16,11 @@ import type {
 // =============================================================================
 
 export const navItems: NavItem[] = [
-  { label: 'The Rose', href: '/the-rose' },
   { label: 'Offerings', href: '/offerings' },
   { label: 'Community', href: '/community' },
+  { label: 'The Rose', href: '/the-rose' },
   { label: 'Guardians', href: '/guardians' },
+  { label: 'Contact', href: '/contact' },
 ];
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Reorganized the navigation menu item order to improve information hierarchy and user experience. The changes prioritize primary actions and group related items together.

## Key Changes
- Moved "Offerings" to the first position as the primary call-to-action
- Repositioned "Community" as the second item to emphasize community engagement
- Moved "The Rose" and "Guardians" to later positions in the navigation flow
- Added missing "Contact" link to the mock data navigation items for consistency

## Implementation Details
- Updated navigation item order in both `src/components/ui/Navigation.tsx` (defaultItems) and `src/lib/data/mock-data.ts` (navItems)
- Ensured consistency between the two navigation sources
- The new order reflects a user journey: Offerings → Community → The Rose → Guardians → Contact

https://claude.ai/code/session_012UMisgyLUEeNGQ5ArDUh6a