### PR TITLE
Add ROSES OS Scope of Work documentation

### DIFF
--- a/docs/brand/scope-of-work.md
+++ b/docs/brand/scope-of-work.md
@@ -1,0 +1,42 @@
+# ROSES OS -- Scope of Work
+
+> Points of Consideration for Collaboration and Stewardship
+
+---
+
+## Ownership & Licensing
+
+### Intellectual Property
+
+All content, materials, teachings, visual assets, and platform infrastructure created under the ROSES OS ecosystem are the intellectual property of **ROSES OS**.
+
+This includes -- but is not limited to -- written teachings, training manuals, meditation guides, brand materials, course content, digital platform code, and design systems.
+
+Ownership of these materials remains with ROSES OS regardless of the contributors, collaborators, or partners involved in their creation or distribution.
+
+### Teaching Use
+
+Content produced within the ROSES OS ecosystem is **free to use for teaching purposes** by any individual who has been initiated into the Rose path.
+
+This applies to personal teaching, group facilitation, workshops, courses, and other educational contexts -- whether offered freely or as part of a paid program. Initiated teachers and practitioners may use ROSES OS content to support their own teaching and the transmission of this work in the world.
+
+### Conditions of Use
+
+The following conditions apply to the use of ROSES OS content:
+
+1. **Initiation** -- The individual must have been initiated into the Rose path through the ROSES OS lineage or its recognized transmission holders.
+2. **Attribution** -- All use of ROSES OS content must credit ROSES OS as the source.
+3. **Integrity of Transmission** -- The teachings must be shared without distortion. The essence, language, and energetic integrity of the original material must be preserved. Adaptations are welcome where they serve clarity, but the core transmission must remain whole.
+4. **Sacred Use** -- In alignment with the agreements honored within this lineage -- confidentiality, co-responsibility, and trust -- materials should be shared only with those who are ready to receive them, and handled with the care they deserve.
+
+### Platform & Infrastructure
+
+The digital platform, codebase, design system, and technical infrastructure of ROSES OS remain proprietary to **ROSES OS** and its development partner, **LIGHT BRANDS**. These assets are not included in the teaching-use provisions above.
+
+### A Living Agreement
+
+This is not a static legal document. It is a living agreement, aligned with the spirit of The Codex:
+
+> "Though it cannot be owned, it can be protected. Though it cannot be patented, it can be transmitted with integrity."
+
+As the ecosystem grows, these terms may evolve -- always in service of the Rose, its guardians, and those called to carry the work forward.


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation outlining the intellectual property, licensing, and usage terms for the ROSES OS ecosystem.

## Changes
- **New document**: `docs/brand/scope-of-work.md` - Establishes the foundational agreement for collaboration and stewardship within ROSES OS

## Key Content
The Scope of Work document defines:
- **Ownership & IP**: All ROSES OS content, materials, and platform infrastructure remain the intellectual property of ROSES OS
- **Teaching Use Rights**: Initiated practitioners are granted free use of ROSES OS content for teaching purposes (personal, group, workshops, paid programs)
- **Conditions of Use**: Four core requirements for authorized use:
  1. Initiation into the Rose path through ROSES OS lineage
  2. Attribution to ROSES OS as the source
  3. Preservation of teaching integrity and essence
  4. Sacred handling aligned with confidentiality and trust agreements
- **Platform Exclusion**: Digital platform, codebase, and technical infrastructure remain proprietary and are not covered by teaching-use provisions
- **Living Agreement**: Acknowledges this as an evolving document that may adapt as the ecosystem grows

This document serves as the governing framework for how ROSES OS content can be shared, taught, and transmitted while protecting the integrity and ownership of the work.

https://claude.ai/code/session_018vuGNCaRXpF6xLk6ZqN52m