### PR TITLE
Convert PdfExportButton to direct download link with multi-language support

### DIFF
--- a/src/components/ui/PdfExportButton.tsx
+++ b/src/components/ui/PdfExportButton.tsx
@@ -4,22 +4,27 @@ import { motion } from 'framer-motion';
 import { FileDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useLanguage } from '@/lib/i18n';
+import { teachersAidPdfConfig } from '@/lib/data/manual-pdf-paths';
 
 interface PdfExportButtonProps {
   className?: string;
 }
 
 export function PdfExportButton({ className }: PdfExportButtonProps) {
-  const { t } = useLanguage();
+  const { locale, t } = useLanguage();
+  const href = teachersAidPdfConfig.paths[locale] ?? teachersAidPdfConfig.paths.en;
+  const label =
+    teachersAidPdfConfig.labels[locale] ??
+    t?.ui.exportTeachersAidPdf ??
+    'Download Teachers Aid PDF';
 
-  function handleExport() {
-    window.print();
-  }
+  if (!href) return null;
 
   return (
-    <motion.button
-      type="button"
-      onClick={handleExport}
+    <motion.a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
       whileHover={{ scale: 1.02 }}
       whileTap={{ scale: 0.98 }}
       className={cn(
@@ -33,8 +38,8 @@ export function PdfExportButton({ className }: PdfExportButtonProps) {
       )}
     >
       <FileDown className="h-4 w-4" />
-      <span>{t?.ui.exportTeachersAidPdf ?? 'Export Teachers Aid PDF'}</span>
-    </motion.button>
+      <span>{label}</span>
+    </motion.a>
   );
 }
 

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -42,6 +42,7 @@ export type { ManualImageEntry, ManualImageMapping } from './manual-image-mappin
 
 export {
   manualPdfConfigs,
+  teachersAidPdfConfig,
   getManualPdfConfig,
 } from './manual-pdf-paths';
 

--- a/src/lib/data/manual-pdf-paths.ts
+++ b/src/lib/data/manual-pdf-paths.ts
@@ -62,6 +62,22 @@ export const manualPdfConfigs: ManualPdfConfig[] = [
   },
 ];
 
+/** Full Teachers Aid PDF — all levels combined, per locale */
+export const teachersAidPdfConfig: Omit<ManualPdfConfig, 'level'> = {
+  paths: {
+    en: '/resources/manuals/ROSES-OS-Teachers-Aid-EN.pdf',
+    es: '/resources/manuals/ROSES-OS-Teachers-Aid-ES.pdf',
+    pt: '/resources/manuals/ROSES-OS-Teachers-Aid-PT.pdf',
+    el: '/resources/manuals/ROSES-OS-Teachers-Aid-EL.pdf',
+  },
+  labels: {
+    en: 'Download Teachers Aid PDF',
+    es: 'Descargar PDF de Ayuda para Profesores',
+    pt: 'Baixar PDF de Auxílio ao Professor',
+    el: 'Λήψη PDF Βοηθήματος Δασκάλου',
+  },
+};
+
 /** Helper to get a config by level number */
 export function getManualPdfConfig(level: number): ManualPdfConfig | undefined {
   return manualPdfConfigs.find((c) => c.level === level);


### PR DESCRIPTION
## Summary
Refactored the PdfExportButton component to provide direct downloads of a comprehensive Teachers Aid PDF instead of triggering the browser's print dialog. Added multi-language support with locale-specific PDF paths and labels.

## Key Changes
- **Component refactor**: Changed PdfExportButton from a button that triggers `window.print()` to an anchor element that directly links to PDF resources
- **Multi-language support**: Integrated locale-aware PDF paths and labels using the new `teachersAidPdfConfig` configuration
- **New configuration**: Added `teachersAidPdfConfig` export in `manual-pdf-paths.ts` containing:
  - Locale-specific PDF paths for English, Spanish, Portuguese, and Greek
  - Translated labels for each supported language
  - Fallback to English if locale is not available
- **Graceful degradation**: Button returns null if no PDF path is available for the current locale
- **Accessibility**: Added `target="_blank"` and `rel="noopener noreferrer"` attributes for secure external link behavior

## Implementation Details
- The component now retrieves the current locale from the `useLanguage()` hook
- PDF paths and labels are centralized in the data configuration layer for easier maintenance
- Maintains existing Framer Motion animations and styling
- Exported the new config from the data index for consistent module organization

https://claude.ai/code/session_01MNSVLYoC9wNhHPBLeWeysv