### PR TITLE
Add reusable LevelNavigation component for teaching levels

### DIFF
--- a/src/app/(teaching)/teaching/level-1/page.tsx
+++ b/src/app/(teaching)/teaching/level-1/page.tsx
@@ -10,6 +10,7 @@ import ManualPdfButton from '@/components/teaching/ManualPdfButton';
 import { manualPdfConfigs } from '@/lib/data/manual-pdf-paths';
 import { ImageDownloadButton } from '@/components/teaching/ImageDownloadButton';
 import LanguageSelector from '@/components/teaching/LanguageSelector';
+import LevelNavigation from '@/components/teaching/LevelNavigation';
 import { useLanguage } from '@/lib/i18n';
 
 export default function Level1Page() {
@@ -87,6 +88,8 @@ export default function Level1Page() {
                 />
               ))}
             </section>
+
+            <LevelNavigation currentLevel={1} />
           </div>
         </main>
       </div>

--- a/src/app/(teaching)/teaching/level-2/page.tsx
+++ b/src/app/(teaching)/teaching/level-2/page.tsx
@@ -11,6 +11,7 @@ import ManualPdfButton from '@/components/teaching/ManualPdfButton';
 import { manualPdfConfigs } from '@/lib/data/manual-pdf-paths';
 import { ImageDownloadButton } from '@/components/teaching/ImageDownloadButton';
 import LanguageSelector from '@/components/teaching/LanguageSelector';
+import LevelNavigation from '@/components/teaching/LevelNavigation';
 import { useLanguage } from '@/lib/i18n';
 
 export default function Level2Page() {
@@ -133,25 +134,7 @@ export default function Level2Page() {
               ))}
             </section>
 
-            {/* Continue to Level 3 */}
-            <div className="border-t border-[var(--color-border)] pt-10">
-              <Link
-                href="/teaching/level-3"
-                className="group flex items-center justify-between rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-6 py-5 transition-all duration-200 hover:border-[var(--color-border)] hover:shadow-sm"
-              >
-                <div className="space-y-1">
-                  <span className="text-xs font-medium uppercase tracking-wider text-[var(--color-foreground-faint)]">
-                    {t?.ui.nextLevel ?? 'Next'}
-                  </span>
-                  <p className="font-serif text-lg text-[var(--color-foreground)]">
-                    {teachingLevels[2]?.title}
-                  </p>
-                </div>
-                <span className="text-[var(--color-foreground-muted)] transition-transform duration-200 group-hover:translate-x-1">
-                  &rarr;
-                </span>
-              </Link>
-            </div>
+            <LevelNavigation currentLevel={2} />
           </div>
         </main>
       </div>

--- a/src/app/(teaching)/teaching/level-3/page.tsx
+++ b/src/app/(teaching)/teaching/level-3/page.tsx
@@ -10,6 +10,7 @@ import ManualPdfButton from '@/components/teaching/ManualPdfButton';
 import { manualPdfConfigs } from '@/lib/data/manual-pdf-paths';
 import { ImageDownloadButton } from '@/components/teaching/ImageDownloadButton';
 import LanguageSelector from '@/components/teaching/LanguageSelector';
+import LevelNavigation from '@/components/teaching/LevelNavigation';
 import { useLanguage } from '@/lib/i18n';
 
 export default function Level3Page() {
@@ -70,6 +71,8 @@ export default function Level3Page() {
                 />
               ))}
             </section>
+
+            <LevelNavigation currentLevel={3} />
           </div>
         </main>
       </div>

--- a/src/components/teaching/LevelNavigation.tsx
+++ b/src/components/teaching/LevelNavigation.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Link from 'next/link';
+import { teachingLevels } from '@/lib/data';
+import { useLanguage } from '@/lib/i18n';
+
+interface LevelNavigationProps {
+  currentLevel: number;
+}
+
+export default function LevelNavigation({ currentLevel }: LevelNavigationProps) {
+  const { t } = useLanguage();
+
+  const prevLevel = teachingLevels.find((l) => l.level === currentLevel - 1);
+  const nextLevel = teachingLevels.find((l) => l.level === currentLevel + 1);
+
+  if (!prevLevel && !nextLevel) return null;
+
+  return (
+    <div className="border-t border-[var(--color-border)] pt-10">
+      <div className={`grid gap-4 ${prevLevel && nextLevel ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-1'}`}>
+        {prevLevel && (
+          <Link
+            href={`/teaching/level-${prevLevel.level}`}
+            className="group flex items-center justify-between rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-6 py-5 transition-all duration-200 hover:border-[var(--color-border)] hover:shadow-sm"
+          >
+            <span className="text-[var(--color-foreground-muted)] transition-transform duration-200 group-hover:-translate-x-1">
+              &larr;
+            </span>
+            <div className="space-y-1 text-right">
+              <span className="text-xs font-medium uppercase tracking-wider text-[var(--color-foreground-faint)]">
+                {t?.ui.previousLevel ?? 'Previous'}
+              </span>
+              <p className="font-serif text-lg text-[var(--color-foreground)]">
+                {prevLevel.title}
+              </p>
+            </div>
+          </Link>
+        )}
+        {nextLevel && (
+          <Link
+            href={`/teaching/level-${nextLevel.level}`}
+            className={`group flex items-center justify-between rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-surface)] px-6 py-5 transition-all duration-200 hover:border-[var(--color-border)] hover:shadow-sm ${prevLevel ? '' : 'sm:col-start-1'}`}
+          >
+            <div className="space-y-1">
+              <span className="text-xs font-medium uppercase tracking-wider text-[var(--color-foreground-faint)]">
+                {t?.ui.nextLevel ?? 'Next'}
+              </span>
+              <p className="font-serif text-lg text-[var(--color-foreground)]">
+                {nextLevel.title}
+              </p>
+            </div>
+            <span className="text-[var(--color-foreground-muted)] transition-transform duration-200 group-hover:translate-x-1">
+              &rarr;
+            </span>
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/content/teaching/el.json
+++ b/src/content/teaching/el.json
@@ -24,7 +24,9 @@
     "rosesOs": "ROSES OS",
     "exportTeachersAidPdf": "Εξαγωγή PDF Βοηθήματος Δασκάλου",
     "downloadImages": "Λήψη Εικόνων",
-    "preparingDownload": "Προετοιμασία λήψης\u2026"
+    "preparingDownload": "Προετοιμασία λήψης\u2026",
+    "nextLevel": "Επόμενο",
+    "previousLevel": "Προηγούμενο"
   },
   "opening": {
     "agreements": {

--- a/src/content/teaching/en.json
+++ b/src/content/teaching/en.json
@@ -24,7 +24,9 @@
     "rosesOs": "ROSES OS",
     "exportTeachersAidPdf": "Export Teachers Aid PDF",
     "downloadImages": "Download Images",
-    "preparingDownload": "Preparing download\u2026"
+    "preparingDownload": "Preparing download\u2026",
+    "nextLevel": "Next",
+    "previousLevel": "Previous"
   },
   "opening": {
     "agreements": {

--- a/src/content/teaching/es.json
+++ b/src/content/teaching/es.json
@@ -24,7 +24,9 @@
     "rosesOs": "ROSES OS",
     "exportTeachersAidPdf": "Exportar PDF de Ayuda para Profesores",
     "downloadImages": "Descargar Imágenes",
-    "preparingDownload": "Preparando descarga\u2026"
+    "preparingDownload": "Preparando descarga\u2026",
+    "nextLevel": "Siguiente",
+    "previousLevel": "Anterior"
   },
   "opening": {
     "agreements": {

--- a/src/content/teaching/pt.json
+++ b/src/content/teaching/pt.json
@@ -24,7 +24,9 @@
     "rosesOs": "ROSES OS",
     "exportTeachersAidPdf": "Exportar PDF de Auxílio ao Professor",
     "downloadImages": "Baixar Imagens",
-    "preparingDownload": "Preparando download\u2026"
+    "preparingDownload": "Preparando download\u2026",
+    "nextLevel": "Próximo",
+    "previousLevel": "Anterior"
   },
   "opening": {
     "agreements": {

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -34,6 +34,8 @@ export interface TeachingTranslations {
     exportTeachersAidPdf: string;
     downloadImages: string;
     preparingDownload: string;
+    nextLevel: string;
+    previousLevel: string;
   };
   opening: {
     agreements: {


### PR DESCRIPTION
## Summary
Refactored level navigation into a reusable `LevelNavigation` component that intelligently displays previous/next level links based on the current level. This eliminates code duplication across teaching level pages and provides consistent navigation patterns.

## Key Changes
- **New Component**: Created `LevelNavigation.tsx` that:
  - Accepts a `currentLevel` prop to determine which navigation links to display
  - Dynamically finds and displays previous/next level links from the teaching levels data
  - Adapts grid layout based on available navigation (single column when only one direction available, two columns when both available)
  - Includes smooth hover animations and responsive design
  
- **Updated Teaching Level Pages**: Replaced hardcoded navigation markup in:
  - `level-1/page.tsx` - Added `LevelNavigation` component
  - `level-2/page.tsx` - Replaced inline navigation with `LevelNavigation` component
  - `level-3/page.tsx` - Added `LevelNavigation` component

- **Internationalization**: Added translation keys to all language files (en, es, pt, el):
  - `nextLevel` - Label for next level navigation
  - `previousLevel` - Label for previous level navigation

## Implementation Details
- Component uses the existing `teachingLevels` data structure to determine available navigation
- Returns `null` if no previous or next level exists (edge case handling)
- Maintains consistent styling with CSS variables and Tailwind classes
- Responsive grid layout: single column on mobile, two columns on larger screens when both navigation options are present
- Includes directional arrow animations that translate on hover for visual feedback

https://claude.ai/code/session_01TEHSNP8po2NJC723zX2Meb