### PR TITLE
Add white background to slide card image containers

### DIFF
--- a/src/components/teaching/ChakraSlideCard.tsx
+++ b/src/components/teaching/ChakraSlideCard.tsx
@@ -55,7 +55,7 @@ export default function ChakraSlideCard({ chakra, index = 0, className }: Chakra
         if (imageSrc) {
           return (
             <div
-              className="relative aspect-[16/10]"
+              className="relative aspect-[16/10] bg-white"
               style={{
                 borderBottom: `2px solid ${chakra.chakraColor}40`,
               }}

--- a/src/components/teaching/TeachingSlideCard.tsx
+++ b/src/components/teaching/TeachingSlideCard.tsx
@@ -48,7 +48,7 @@ export default function TeachingSlideCard({ slide, index = 0, className }: Teach
     >
       {/* Image Area */}
       {imageSrc ? (
-        <div className="relative aspect-[16/10]">
+        <div className="relative aspect-[16/10] bg-white">
           <img
             src={imageSrc}
             alt={concept}


### PR DESCRIPTION
## Summary
Added white background color to image container elements in slide card components to improve visual consistency and ensure proper contrast for displayed images.

## Key Changes
- Added `bg-white` class to the image container div in `ChakraSlideCard.tsx`
- Added `bg-white` class to the image container div in `TeachingSlideCard.tsx`

## Implementation Details
Both components use a 16:10 aspect ratio container for displaying images. The white background ensures that images have a consistent, clean backdrop and prevents any transparency or inherited background colors from affecting the image display.

https://claude.ai/code/session_01WDimR5vMvGg7sGB7WCaeBv