### PR TITLE
Add footnote indicator to Rose Meditation Guidance sessions

### DIFF
--- a/docs/program/presentation.md
+++ b/docs/program/presentation.md
@@ -163,11 +163,11 @@ No belief required. Only presence and willingness to return to your essence. The
 *We have different schedules during the week and weekend.*
 
 - **1st Week:** March 19th -- 20th (Thursday and Friday)
-  - Rose Meditation Guidance (30 min), First Class (2 hours), Second Class (2 hours)
+  - Rose Meditation Guidance* (30 min), First Class (2 hours), Second Class (2 hours)
 - **Weekend:** March 21st -- 22nd (Saturday and Sunday)
-  - Rose Meditation Guidance (30 min), First Class (3 hours), Second Class (3 hours)
+  - Rose Meditation Guidance* (30 min), First Class (3 hours), Second Class (3 hours)
 - **2nd Week:** March 23rd -- 27th (Monday to Friday)
-  - Rose Meditation Guidance (30 min), Class (3 hours), Practices (1.5 hours each -- choose at least one)
+  - Rose Meditation Guidance* (30 min), Class (3 hours), Practices (1.5 hours each -- choose at least one)
 
 *For detailed times across all time zones, see the full schedule on the Learn More page.*
 
@@ -198,5 +198,7 @@ She practices the pedagogical methods and integration, ensuring the teachings re
 ## Begin
 
 **Start your journey.**
+
+*\* For the most up-to-date information on times and dates, please check the WhatsApp channel.*
 
 *Welcome home.*

--- a/docs/program/schedule-details.md
+++ b/docs/program/schedule-details.md
@@ -40,7 +40,7 @@
 
 ### 1st Week Classes -- 19th and 20th (Thursday and Friday)
 
-**Rose Meditation Guidance (30 min)**
+**Rose Meditation Guidance* (30 min)**
 
 | Time Zone | Hours |
 |---|---|
@@ -71,7 +71,7 @@
 
 ### Weekend -- 21st and 22nd of March (Saturday and Sunday)
 
-**Rose Meditation Guidance (30 min)**
+**Rose Meditation Guidance* (30 min)**
 
 | Time Zone | Hours |
 |---|---|
@@ -104,7 +104,7 @@
 
 *The classes are mandatory, but the practices can be chosen between the first or second period -- of course if you come to both, you are more than welcome, but one is enough!*
 
-**Rose Meditation Guidance (30 min)**
+**Rose Meditation Guidance* (30 min)**
 
 | Time Zone | Hours |
 |---|---|
@@ -153,7 +153,7 @@
 
 ### Special Practice Day -- 27th of March (Friday)
 
-**Rose Meditation Guidance (30 min)**
+**Rose Meditation Guidance* (30 min)**
 
 | Time Zone | Hours |
 |---|---|
@@ -184,6 +184,10 @@ This work is offered in devotion. You are invited to choose a contribution that 
 | Above $70,000 USD | Higher tier -- supports accessibility for others and the expansion of this work |
 
 Your support allows these technologies to reach more people worldwide.
+
+---
+
+*\* For the most up-to-date information on times and dates, please check the WhatsApp channel.*
 
 ---
 

--- a/src/components/sections/ScheduleTable.tsx
+++ b/src/components/sections/ScheduleTable.tsx
@@ -160,6 +160,11 @@ export default function ScheduleTable({ stages, className }: ScheduleTableProps)
           </div>
         ))}
       </div>
+
+      {/* WhatsApp footnote */}
+      <p className="text-xs text-[var(--color-foreground-faint)] mt-4 italic">
+        * For the most up-to-date information on times and dates, please check the WhatsApp channel.
+      </p>
     </motion.div>
   );
 }

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -142,7 +142,7 @@ export const scheduleStages: ScheduleStage[] = [
     title: 'Aura Reading: Week 1 Weekdays',
     dateRange: 'March 19–20 (Thu & Fri)',
     sessions: [
-      { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
+      { day: 'Rose Meditation Guidance*', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
       { day: 'First Class', duration: '2 hours', time: { sanJose: '8:00 – 10:00 AM', bogota: '9:00 – 11:00 AM', newYork: '10:00 AM – 12:00 PM', brasilia: '11:00 AM – 1:00 PM', london: '2:00 – 4:00 PM', madrid: '3:00 – 5:00 PM' } },
       { day: 'Second Class', duration: '2 hours', time: { sanJose: '11:00 AM – 1:00 PM', bogota: '12:00 – 2:00 PM', newYork: '1:00 – 3:00 PM', brasilia: '2:00 – 4:00 PM', london: '5:00 – 7:00 PM', madrid: '6:00 – 8:00 PM' } },
     ],
@@ -152,7 +152,7 @@ export const scheduleStages: ScheduleStage[] = [
     title: 'Aura Reading: Weekend',
     dateRange: 'March 21–22 (Sat & Sun)',
     sessions: [
-      { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
+      { day: 'Rose Meditation Guidance*', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
       { day: 'First Class', duration: '3 hours', time: { sanJose: '8:00 – 11:00 AM', bogota: '9:00 AM – 12:00 PM', newYork: '10:00 AM – 1:00 PM', brasilia: '11:00 AM – 2:00 PM', london: '2:00 – 5:00 PM', madrid: '3:00 – 6:00 PM' } },
       { day: 'Second Class', duration: '3 hours', time: { sanJose: '12:30 – 3:30 PM', bogota: '1:30 – 4:30 PM', newYork: '2:30 – 5:30 PM', brasilia: '3:30 – 6:30 PM', london: '6:30 – 9:30 PM', madrid: '7:30 – 10:30 PM' } },
     ],
@@ -162,7 +162,7 @@ export const scheduleStages: ScheduleStage[] = [
     title: 'Aura Reading: Week 2',
     dateRange: 'March 23–26 (Mon–Thu)',
     sessions: [
-      { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
+      { day: 'Rose Meditation Guidance*', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
       { day: 'Class (mandatory)', duration: '3 hours', time: { sanJose: '8:00 – 11:00 AM', bogota: '9:00 AM – 12:00 PM', newYork: '10:00 AM – 1:00 PM', brasilia: '11:00 AM – 2:00 PM', london: '2:00 – 5:00 PM', madrid: '3:00 – 6:00 PM' } },
       { day: 'Practice 1: Europe', duration: '1.5 hours', time: { sanJose: '-', bogota: '-', newYork: '-', brasilia: '8:00 – 9:30 AM', london: '11:00 AM – 12:30 PM', madrid: '12:00 – 1:30 PM' } },
       { day: 'Practice 2', duration: '1.5 hours', time: { sanJose: '12:00 – 1:30 PM', bogota: '1:00 – 2:30 PM', newYork: '2:00 – 3:30 PM', brasilia: '3:00 – 4:30 PM', london: '6:00 – 7:30 PM', madrid: '7:00 – 8:30 PM' } },
@@ -174,7 +174,7 @@ export const scheduleStages: ScheduleStage[] = [
     title: 'Special Practice Day',
     dateRange: 'March 27 (Fri)',
     sessions: [
-      { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
+      { day: 'Rose Meditation Guidance*', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '1:00 – 1:30 PM', madrid: '2:00 – 2:30 PM' } },
       { day: 'Q&A and Practice Time', duration: '3 hours', time: { sanJose: '8:00 – 11:00 AM', bogota: '9:00 AM – 12:00 PM', newYork: '10:00 AM – 1:00 PM', brasilia: '11:00 AM – 2:00 PM', london: '2:00 – 5:00 PM', madrid: '3:00 – 6:00 PM' } },
     ],
   },
@@ -206,7 +206,7 @@ export const aura2ScheduleStages: ScheduleStage[] = [
     title: 'Aura Reading Level 2: Weekends',
     dateRange: 'September 19, 20, 26 & 27 (Sat & Sun)',
     sessions: [
-      { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '2:00 – 2:30 PM', madrid: '3:00 – 3:30 PM' } },
+      { day: 'Rose Meditation Guidance*', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '2:00 – 2:30 PM', madrid: '3:00 – 3:30 PM' } },
       { day: 'First Class', duration: '2.5 hours', time: { sanJose: '8:00 – 10:30 AM', bogota: '9:00 – 11:30 AM', newYork: '10:00 AM – 12:30 PM', brasilia: '11:00 AM – 1:30 PM', london: '3:00 – 5:30 PM', madrid: '4:00 – 6:30 PM' } },
       { day: 'Second Class', duration: '2.5 hours', time: { sanJose: '12:00 – 2:30 PM', bogota: '1:00 – 3:30 PM', newYork: '2:00 – 4:30 PM', brasilia: '3:00 – 5:30 PM', london: '7:00 – 9:30 PM', madrid: '8:00 – 10:30 PM' } },
     ],
@@ -216,7 +216,7 @@ export const aura2ScheduleStages: ScheduleStage[] = [
     title: 'Aura Reading Level 2: Weekdays',
     dateRange: 'September 21–25 (Mon–Fri)',
     sessions: [
-      { day: 'Rose Meditation Guidance', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '2:00 – 2:30 PM', madrid: '3:00 – 3:30 PM' } },
+      { day: 'Rose Meditation Guidance*', duration: '30 min', time: { sanJose: '7:00 – 7:30 AM', bogota: '8:00 – 8:30 AM', newYork: '9:00 – 9:30 AM', brasilia: '10:00 – 10:30 AM', london: '2:00 – 2:30 PM', madrid: '3:00 – 3:30 PM' } },
       { day: 'First Practice (choose at least one)', duration: '1.5 hours', time: { sanJose: '8:00 – 9:30 AM', bogota: '9:00 – 10:30 AM', newYork: '10:00 – 11:30 AM', brasilia: '11:00 AM – 12:30 PM', london: '3:00 – 4:30 PM', madrid: '4:00 – 5:30 PM' } },
       { day: 'Second Practice (choose at least one)', duration: '1.5 hours', time: { sanJose: '10:00 – 11:30 AM', bogota: '11:00 AM – 12:30 PM', newYork: '12:00 – 1:30 PM', brasilia: '1:00 – 2:30 PM', london: '5:00 – 6:30 PM', madrid: '6:00 – 7:30 PM' } },
       { day: 'Class', duration: '1.5 hours', time: { sanJose: '12:00 – 1:30 PM', bogota: '1:00 – 2:30 PM', newYork: '2:00 – 3:30 PM', brasilia: '3:00 – 4:30 PM', london: '7:00 – 8:30 PM', madrid: '8:00 – 9:30 PM' } },


### PR DESCRIPTION
## Summary
Added a footnote indicator (*) to all "Rose Meditation Guidance" session titles across the schedule documentation and data, with a corresponding footnote directing users to check the WhatsApp channel for the most up-to-date information on times and dates.

## Key Changes
- Updated all "Rose Meditation Guidance" references to "Rose Meditation Guidance*" in:
  - Schedule details documentation (4 occurrences across different program weeks)
  - Mock schedule data for both Aura Reading Level 1 and Level 2 programs (6 occurrences)
  - Program presentation documentation (3 occurrences)
- Added footnote text to three locations:
  - Schedule details page (after the schedule section)
  - Program presentation page (at the end of content)
  - ScheduleTable component (as a rendered footnote below the schedule)

## Implementation Details
- The asterisk (*) is appended directly to the session title in data structures and documentation
- Footnote text is consistent across all locations: "*\* For the most up-to-date information on times and dates, please check the WhatsApp channel."
- The ScheduleTable component footnote is styled with small text and faint foreground color to maintain visual hierarchy
- Changes maintain consistency between documentation, mock data, and rendered components

https://claude.ai/code/session_01UiAXgqDrbHebMmkEe5ph8z