### PR TITLE
Add Google Calendar links to free community programs

### DIFF
--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -548,6 +548,8 @@ export const freePrograms: CommunityProgram[] = [
     schedule: 'Every Saturday, 10:30 AM – 11:30 AM (Costa Rica time)',
     free: true,
     whatsappLink: 'https://chat.whatsapp.com/C2C0DgvSVtW3fOB231vpRc?mode=gi_t',
+    calendarLink: 'https://calendar.google.com/calendar/ical/f1e7e75c76e2a9d7f4f838fada59614be672a8e780a25a39a518fe29f243d389%40group.calendar.google.com/public/basic.ics',
+    googleCalendarUrl: 'https://calendar.google.com/calendar/u/1?cid=ZjFlN2U3NWM3NmUyYTlkN2Y0ZjgzOGZhZGE1OTYxNGJlNjcyYThlNzgwYTI1YTM5YTUxOGZlMjlmMjQzZDM4OUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t',
   },
   {
     id: 'free-live-guidances',
@@ -557,6 +559,8 @@ export const freePrograms: CommunityProgram[] = [
     audience: 'Rose Meditation Practitioner',
     free: true,
     whatsappLink: 'https://chat.whatsapp.com/Lh6bJlDmliMIryvKz63tzi?mode=gi_t',
+    calendarLink: 'https://calendar.google.com/calendar/ical/08e5422245d1b02dabc429630bfe6086229c73da3d4d6aa6c4024429256467f9%40group.calendar.google.com/public/basic.ics',
+    googleCalendarUrl: 'https://calendar.google.com/calendar/u/1?cid=MDhlNTQyMjI0NWQxYjAyZGFiYzQyOTYzMGJmZTYwODYyMjljNzNkYTNkNGQ2YWE2YzQwMjQ0MjkyNTY0NjdmOUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t',
     scheduleCycles: [
       {
         id: 'guidances-feb-jun',


### PR DESCRIPTION
## Summary
Added Google Calendar integration links to two free community programs, enabling users to subscribe to and view program schedules directly in Google Calendar.

## Key Changes
- Added `calendarLink` (iCal format) and `googleCalendarUrl` properties to the "Rose Meditation" program
- Added `calendarLink` (iCal format) and `googleCalendarUrl` properties to the "Free Live Guidances" program

## Implementation Details
Each program now includes:
- **calendarLink**: An iCal feed URL for calendar subscription
- **googleCalendarUrl**: A direct Google Calendar subscription link that opens the calendar in Google Calendar interface

This allows users to easily add these community programs to their personal calendars through their preferred method.

https://claude.ai/code/session_012oqQXnxUoaHiQPkauV46eW