### PR TITLE
Reorder community sections and improve offerings navigation

### DIFF
--- a/src/app/(site)/community/CommunityClient.tsx
+++ b/src/app/(site)/community/CommunityClient.tsx
@@ -314,7 +314,49 @@ export default function CommunityClient() {
         image="/page-images/page-community.png"
       />
 
-      {/* 2. Community Vision */}
+      {/* 2. Free Activities */}
+      <section ref={freeRef} className="section-padding">
+        <div className="container-premium max-w-3xl mx-auto">
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={freeInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.6, ease }}
+            className="label-sacred mb-6"
+          >
+            Free Activities
+          </motion.p>
+          <motion.h2
+            initial={{ opacity: 0, y: 24 }}
+            animate={freeInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.1, ease }}
+            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-4"
+          >
+            Open to All
+          </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 24 }}
+            animate={freeInView ? { opacity: 1, y: 0 } : {}}
+            transition={{ duration: 0.6, delay: 0.15, ease }}
+            className="text-base text-[var(--color-foreground-muted)] leading-relaxed mb-8"
+          >
+            These gatherings are offered freely as a gift to the community.
+            Whether you are new to the Rose field or a long-time practitioner,
+            there is a place for you here.
+          </motion.p>
+          <div className="space-y-4">
+            {freePrograms.map((program, i) => (
+              <ActivityCard
+                key={program.id}
+                program={program}
+                index={i}
+                inView={freeInView}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 3. Community Vision */}
       <section ref={visionRef} className="section-padding">
         <div className="container-premium max-w-3xl mx-auto">
           <motion.p
@@ -357,48 +399,6 @@ export default function CommunityClient() {
               the field and touches everyone around them.
             </p>
           </motion.div>
-        </div>
-      </section>
-
-      {/* 3. Free Activities */}
-      <section ref={freeRef} className="section-padding">
-        <div className="container-premium max-w-3xl mx-auto">
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={freeInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6, ease }}
-            className="label-sacred mb-6"
-          >
-            Free Activities
-          </motion.p>
-          <motion.h2
-            initial={{ opacity: 0, y: 24 }}
-            animate={freeInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6, delay: 0.1, ease }}
-            className="font-serif text-[clamp(1.5rem,3.5vw,2.5rem)] leading-tight tracking-tight mb-4"
-          >
-            Open to All
-          </motion.h2>
-          <motion.p
-            initial={{ opacity: 0, y: 24 }}
-            animate={freeInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6, delay: 0.15, ease }}
-            className="text-base text-[var(--color-foreground-muted)] leading-relaxed mb-8"
-          >
-            These gatherings are offered freely as a gift to the community.
-            Whether you are new to the Rose field or a long-time practitioner,
-            there is a place for you here.
-          </motion.p>
-          <div className="space-y-4">
-            {freePrograms.map((program, i) => (
-              <ActivityCard
-                key={program.id}
-                program={program}
-                index={i}
-                inView={freeInView}
-              />
-            ))}
-          </div>
         </div>
       </section>
 

--- a/src/app/(site)/offerings/OfferingsClient.tsx
+++ b/src/app/(site)/offerings/OfferingsClient.tsx
@@ -293,8 +293,18 @@ function OfferingsContent() {
 
       {/* Download PDF Guides */}
       <div className="flex flex-wrap justify-center gap-3 py-6 print:hidden">
-        <SummaryDownloadButton variant="light" />
         <MeditationPdfButton variant="light" />
+        <Link
+          href="/community"
+          className={cn(
+            'inline-flex items-center gap-2 px-6 py-2.5 rounded-full',
+            'text-sm font-medium',
+            'transition-all duration-300',
+            'border border-[var(--color-rose-clay)]/30 text-[var(--color-foreground)]/70 hover:bg-[var(--color-rose-clay)]/5 hover:text-[var(--color-foreground)]',
+          )}
+        >
+          See Our Free Activities in Community
+        </Link>
       </div>
 
       {/* 2. Programs — progressive disclosure */}
@@ -362,6 +372,13 @@ function OfferingsContent() {
                         {(program.id === '1' || program.id === '3') && (
                           <div className="mt-6 flex justify-center print:hidden">
                             <MeditationPdfButton variant="light" />
+                          </div>
+                        )}
+
+                        {/* Program Guide download — Aura 2 */}
+                        {program.id === '2' && (
+                          <div className="mt-6 flex justify-center print:hidden">
+                            <SummaryDownloadButton variant="light" />
                           </div>
                         )}
 

--- a/src/components/ui/SummaryDownloadButton.tsx
+++ b/src/components/ui/SummaryDownloadButton.tsx
@@ -59,7 +59,7 @@ export default function SummaryDownloadButton({ className, variant = 'dark' }: S
       ) : (
         <Download className="w-4 h-4" />
       )}
-      <span>{loading ? 'Generating PDF...' : 'Download Program Guide'}</span>
+      <span>{loading ? 'Generating PDF...' : 'Aura 1 & 2 Program Guide'}</span>
     </motion.button>
   );
 }


### PR DESCRIPTION
## Summary
This PR reorganizes the community page layout by moving the "Free Activities" section before "Community Vision", and improves the offerings page by adding a link to free community activities while relocating the program guide download button.

## Key Changes

- **Community page restructuring**: Moved the "Free Activities" section (now section 2) to appear before "Community Vision" (now section 3), improving the content flow by presenting free offerings earlier in the user journey

- **Offerings page navigation**: 
  - Removed the "Download Program Guide" button from the top-level download section
  - Added a new link to "See Our Free Activities in Community" in the offerings page
  - Relocated the program guide download button to appear specifically within the Aura 2 program details section

- **Button label clarification**: Updated the program guide download button text from "Download Program Guide" to "Aura 1 & 2 Program Guide" for better clarity about which programs the guide covers

## Implementation Details

- The section reordering maintains all existing animation and styling properties
- The new community link uses consistent styling with the existing button variants
- The program guide download is now contextually placed within the Aura 2 program section, making it more discoverable for users exploring that specific offering
- All ref assignments and animation triggers remain properly configured for the reordered sections

https://claude.ai/code/session_011VQVpr2zWMMoCHsPZ91zgJ