### PR TITLE
Fix white rectangles on teaching slides by using site background color

### DIFF
--- a/docs/project-plan-for-designer-action-steps.md
+++ b/docs/project-plan-for-designer-action-steps.md
@@ -191,7 +191,7 @@ The `/teaching` page shows visible background rectangles behind slide images. Th
 | Teaching Slide Card | `src/components/teaching/TeachingSlideCard.tsx` |
 | Chakra Slide Card | `src/components/teaching/ChakraSlideCard.tsx` |
 
-- [x] **3. Fix white rectangles on teaching slides** -- Remove the background color on the image container in both `TeachingSlideCard.tsx` and `ChakraSlideCard.tsx`. Removed `bg-[var(--color-background-subtle)]` from image containers.
+- [x] **3. Fix white rectangles on teaching slides** -- Changed image container backgrounds in both `TeachingSlideCard.tsx` and `ChakraSlideCard.tsx` from `bg-white` to `bg-[var(--color-warm-50)]` (`#F7F5F2` — the site background color) so the containers blend with the page instead of showing a visible white rectangle.
 
 ### Teachers Aid PDF -- 404 Not Found
 

--- a/src/components/teaching/ChakraSlideCard.tsx
+++ b/src/components/teaching/ChakraSlideCard.tsx
@@ -55,7 +55,7 @@ export default function ChakraSlideCard({ chakra, index = 0, className }: Chakra
         if (imageSrc) {
           return (
             <div
-              className="relative aspect-[16/10] bg-white"
+              className="relative aspect-[16/10] bg-[var(--color-warm-50)]"
               style={{
                 borderBottom: `2px solid ${chakra.chakraColor}40`,
               }}

--- a/src/components/teaching/TeachingSlideCard.tsx
+++ b/src/components/teaching/TeachingSlideCard.tsx
@@ -48,7 +48,7 @@ export default function TeachingSlideCard({ slide, index = 0, className }: Teach
     >
       {/* Image Area */}
       {imageSrc ? (
-        <div className="relative aspect-[16/10] bg-white">
+        <div className="relative aspect-[16/10] bg-[var(--color-warm-50)]">
           <img
             src={imageSrc}
             alt={concept}


### PR DESCRIPTION
## Summary
Updated the image container backgrounds on teaching slide cards to use the site's warm background color instead of white, eliminating the visible white rectangles that appeared behind slide images.

## Changes
- **TeachingSlideCard.tsx**: Changed image container background from `bg-white` to `bg-[var(--color-warm-50)]`
- **ChakraSlideCard.tsx**: Changed image container background from `bg-white` to `bg-[var(--color-warm-50)]`
- **Documentation**: Updated project plan to reflect the actual implementation approach

## Implementation Details
The image containers now use `bg-[var(--color-warm-50)]` which corresponds to `#F7F5F2` — the site's background color. This allows the containers to blend seamlessly with the page background instead of creating a visible white rectangle behind the slide images. Both teaching slide card components were updated consistently to maintain uniform styling across the teaching section.

https://claude.ai/code/session_016Me6oQxwZ4GP4g236dJWTf