### PR TITLE
Remove contribution step from enrollment form

### DIFF
--- a/src/app/(forms)/enroll/page.tsx
+++ b/src/app/(forms)/enroll/page.tsx
@@ -5,9 +5,8 @@ import Link from 'next/link';
 import { motion, useInView } from 'framer-motion';
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
-import { agreements, contributionTiers } from '@/lib/data';
+import { agreements } from '@/lib/data';
 import { FormStepper } from '@/components/forms/FormStepper';
-import ContributionForm from '@/components/forms/ContributionForm';
 
 const ease = [0.16, 1, 0.3, 1] as const;
 
@@ -49,7 +48,7 @@ export default function EnrollPage() {
   return (
     <div className="space-y-8">
       <FormStepper
-        steps={['Agreements', 'Contact Dara', 'Contribute']}
+        steps={['Agreements', 'Contact Dara']}
         currentStep={currentStep}
       />
 
@@ -241,7 +240,7 @@ export default function EnrollPage() {
               &larr; Back to Agreements
             </button>
             <button
-              onClick={() => setCurrentStep(3)}
+              onClick={() => setSubmitted(true)}
               className={cn(
                 'px-8 py-3.5 rounded-full',
                 'bg-[var(--color-rose-500)] text-white',
@@ -250,46 +249,7 @@ export default function EnrollPage() {
                 'transition-colors duration-200'
               )}
             >
-              Continue to Contribution
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* ================================================================
-          STEP 3: Contribution
-          ================================================================ */}
-      {currentStep === 3 && (
-        <div className="space-y-8">
-          <motion.div
-            initial={{ opacity: 0, y: 24 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, ease }}
-            className="text-center space-y-3"
-          >
-            <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-[var(--color-foreground-faint)]">
-              Step 3
-            </p>
-            <h1 className="font-serif text-3xl md:text-4xl text-[var(--color-foreground)]">
-              Choose Your Contribution
-            </h1>
-            <p className="text-[var(--color-foreground-muted)] max-w-md mx-auto">
-              We trust you to choose what feels right for where you are
-              in life. There is no judgment, only gratitude.
-            </p>
-          </motion.div>
-
-          <ContributionForm
-            tiers={contributionTiers}
-            onSubmit={() => setSubmitted(true)}
-          />
-
-          <div className="text-center pt-2">
-            <button
-              onClick={() => setCurrentStep(2)}
-              className="text-sm text-[var(--color-foreground-muted)] hover:text-[var(--color-foreground)] transition-colors"
-            >
-              &larr; Back to Contact
+              Complete Enrollment
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Simplified the enrollment form by removing the third step (contribution selection). The form now completes after users provide contact information, eliminating the separate contribution tier selection flow.

## Key Changes
- Removed the "Contribute" step from the form stepper (now only shows "Agreements" and "Contact Dara")
- Deleted the entire Step 3 contribution UI section, including the contribution form component and related messaging
- Changed the final "Continue to Contribution" button to "Complete Enrollment" which now directly sets the submitted state
- Removed unused imports: `contributionTiers` from data and `ContributionForm` component
- Updated the button click handler from `setCurrentStep(3)` to `setSubmitted(true)` to complete the enrollment flow

## Implementation Details
The contribution selection functionality has been completely removed from the enrollment page. Users now complete the enrollment process after filling out agreements and contact information. The `ContributionForm` component and related tier data are no longer used in this flow.

https://claude.ai/code/session_01YTLMHY63ecN76hexfdCxVX