### PR TITLE
Update enrollment messaging and offerings section labels

### DIFF
--- a/src/app/(forms)/enroll/page.tsx
+++ b/src/app/(forms)/enroll/page.tsx
@@ -27,12 +27,11 @@ export default function EnrollPage() {
       <div className="space-y-8 text-center py-12">
         <div className="space-y-3">
           <h1 className="font-serif text-3xl md:text-4xl text-[var(--color-foreground)]">
-            Thank You
+            Thank You for Reaching Out
           </h1>
           <p className="text-[var(--color-foreground-muted)] max-w-md mx-auto">
-            Your enrollment is complete. We are honored to welcome you into
-            the ROSES OS community. You will receive a confirmation email
-            with next steps shortly.
+            Thank you for reaching out. We are honored by your interest in
+            the ROSES OS community. We will be in touch with you shortly.
           </p>
         </div>
         <Link

--- a/src/app/(site)/offerings/OfferingsClient.tsx
+++ b/src/app/(site)/offerings/OfferingsClient.tsx
@@ -295,8 +295,8 @@ function OfferingsContent() {
       <nav className="sticky top-16 lg:top-[72px] z-30 bg-[var(--color-background)]/90 backdrop-blur-lg border-b border-[var(--color-border-subtle)] print:hidden">
         <div className="container-premium flex items-center justify-center gap-1 sm:gap-2 py-3 overflow-x-auto">
           {[
-            { label: 'Programs', id: 'programs-section' },
-            { label: 'Continued', id: 'continued-section' },
+            { label: 'Foundations', id: 'programs-section' },
+            { label: 'Ongoing', id: 'continued-section' },
           ].map((tab) => (
             <button
               key={tab.id}
@@ -520,7 +520,7 @@ function OfferingsContent() {
             transition={{ duration: 0.6, ease }}
             className="label-sacred mb-6"
           >
-            Continued Programs
+            Ongoing Programs
           </motion.p>
           <motion.h2
             initial={{ opacity: 0, y: 24 }}

--- a/src/app/api/pdf/paid-programs/route.ts
+++ b/src/app/api/pdf/paid-programs/route.ts
@@ -641,7 +641,7 @@ export async function GET() {
 
       const aflProg = paidPrograms.find(p => p.id === 'aura-for-life');
       if (aflProg) {
-        y = drawSectionLabel(page, 'Continued Practice', y, sansBold);
+        y = drawSectionLabel(page, 'Ongoing Practice', y, sansBold);
         y = drawHeading(page, 'Aura for Life', y, serifFont, 26);
         y -= 4;
 


### PR DESCRIPTION
## Summary
This PR updates user-facing messaging across the enrollment confirmation page and offerings section to better reflect the nature of the programs and improve clarity for users.

## Key Changes
- **Enrollment page**: Updated the confirmation message from "Thank You" to "Thank You for Reaching Out" and revised the descriptive text to indicate that the form was an inquiry rather than a completed enrollment, with follow-up communication expected
- **Offerings navigation**: Renamed section labels for clarity:
  - "Programs" → "Foundations" (for the initial programs section)
  - "Continued" → "Ongoing" (for the continued programs section)
- **PDF export**: Updated the paid programs PDF section label from "Continued Practice" to "Ongoing Practice" for consistency

## Implementation Details
These changes improve the user experience by:
- Clarifying that the enrollment form is an initial inquiry/contact form rather than a final enrollment step
- Using more intuitive terminology ("Foundations" and "Ongoing") that better describes the program progression
- Maintaining consistency across the web interface and PDF exports

https://claude.ai/code/session_01VebRLBtJgTqP8TZYpLpjK3