### PR TITLE
Change TeachingSlideCard image background from warm-50 to white

### DIFF
--- a/src/components/teaching/TeachingSlideCard.tsx
+++ b/src/components/teaching/TeachingSlideCard.tsx
@@ -48,7 +48,7 @@ export default function TeachingSlideCard({ slide, index = 0, className }: Teach
     >
       {/* Image Area */}
       {imageSrc ? (
-        <div className="relative aspect-[16/10] bg-[var(--color-warm-50)]">
+        <div className="relative aspect-[16/10] bg-white">
           <img
             src={imageSrc}
             alt={concept}


### PR DESCRIPTION
## Summary
Updated the background color of the image container in the TeachingSlideCard component from a warm neutral tone to white for improved visual consistency.

## Changes
- Changed the image area background color from `bg-[var(--color-warm-50)]` to `bg-white` in TeachingSlideCard component

## Details
This change simplifies the color scheme by using a standard white background instead of a custom warm-50 color variable. This may improve visual consistency with other components or better accommodate the images displayed in the teaching slides.

https://claude.ai/code/session_011aYt3A2aGNDAp7nGG4Bq3m