### PR TITLE
Add visual elements to teaching page content sections

### DIFF
--- a/docs/project-plan-for-designer-action-steps.md
+++ b/docs/project-plan-for-designer-action-steps.md
@@ -166,6 +166,20 @@ The combined Level 1&2 PDF is being split. This manual becomes **Level 2 only**.
 
 ## WEBSITE & PDF FIXES
 
+### Teachers Aid Main Page -- Add Visual Elements to Content Sections
+
+The `/teaching` main page has three content sections (teaching slides) that are currently plain text cards with no visual anchors:
+
+1. **Agreements & Virtues** -- core agreements participants honor
+2. **Sacred Companion** -- guidelines for the sacredness of the work
+3. **History & Lineage** -- context about the teaching tradition
+
+- [ ] **Add small icons, illustrations, or visual elements above each section title** -- These are teaching slides and would benefit from a visual element above each heading to set the tone and help distinguish the sections. Designer has creative freedom on what works best — small icons, line illustrations, or other subtle visual touches. Should feel consistent with the rest of the teaching section and use brand accent colors (Antique Olive Brass `#9E956B` or Rose Clay Mauve `#9C6F6E`). Keep it minimal and aligned with the sacred-tech aesthetic.
+
+**File:** `src/app/(teaching)/teaching/page.tsx`
+
+---
+
 ### Teachers Aid PDF -- 404 Not Found
 
 The "Export Teachers Aid PDF" button on the `/teaching` page links to `ROSES-OS-Teachers-Aid-EN.pdf` (and ES/PT/EL variants) in `public/resources/manuals/`, but these files do not exist. The button is wired up in `src/components/ui/PdfExportButton.tsx` using paths from `src/lib/data/manual-pdf-paths.ts`.


### PR DESCRIPTION
## Summary
Updated the project plan documentation to include a new design task for adding visual elements to the Teachers Aid main page content sections.

## Changes
- Added a new task under "WEBSITE & PDF FIXES" section in the project plan
- Documented the need to add visual elements (icons, illustrations, or subtle visual touches) to three content sections on the `/teaching` page:
  - Agreements & Virtues
  - Sacred Companion
  - History & Lineage
- Specified design requirements including:
  - Visual elements should appear above each section title
  - Should use brand accent colors (Antique Olive Brass `#9E956B` or Rose Clay Mauve `#9C6F6E`)
  - Should maintain consistency with the sacred-tech aesthetic
  - Designer has creative freedom on implementation approach
- Referenced the target file: `src/app/(teaching)/teaching/page.tsx`

## Notes
This is a documentation update to the project plan capturing a design task for future implementation. No source code changes are included in this commit.

https://claude.ai/code/session_01AUwaFRiPjcm1iEn789GNFV