### PR TITLE
Hide thorns and leaves from rose model, add illustration guidelines

### DIFF
--- a/src/components/three/RoseModel.tsx
+++ b/src/components/three/RoseModel.tsx
@@ -38,12 +38,6 @@ export default function RoseModel({ mouseRef, reducedMotion, isDark }: RoseModel
       metalness: 0.05,
       side: THREE.DoubleSide,
     });
-    const leafMaterial = new THREE.MeshStandardMaterial({
-      color: '#3A7D44',
-      roughness: 0.5,
-      metalness: 0.0,
-      side: THREE.DoubleSide,
-    });
     const stemMaterial = new THREE.MeshStandardMaterial({
       color: '#2D5E34',
       roughness: 0.6,
@@ -56,11 +50,23 @@ export default function RoseModel({ mouseRef, reducedMotion, isDark }: RoseModel
         child.castShadow = true;
         child.receiveShadow = true;
         const name = (child.name || '').toLowerCase();
+
+        // Thorns are never shown on roses in this practice
+        if (name.includes('thorn')) {
+          child.visible = false;
+          return;
+        }
+
+        // Leaves are de-emphasized — roses are typically shown with
+        // stems (or no stems) rather than with prominent leaves
+        if (name.includes('leaf')) {
+          child.visible = false;
+          return;
+        }
+
         if (name.includes('petal') || name.includes('rose')) {
           child.material = petalMaterial;
-        } else if (name.includes('leaf')) {
-          child.material = leafMaterial;
-        } else if (name.includes('stem') || name.includes('thorn')) {
+        } else if (name.includes('stem')) {
           child.material = stemMaterial;
         } else {
           child.material = petalMaterial;

--- a/src/lib/data/teaching-slides.ts
+++ b/src/lib/data/teaching-slides.ts
@@ -52,6 +52,8 @@ export const level1Slides: TeachingSlide[] = [
       'The Rose is the foundational symbol and tool of this practice — a living energetic instrument used throughout all levels of the work.',
     reimaginedImage: 'level-1/01-the-rose.PNG',
     final: true,
+    imageNote:
+      'Rose illustration guideline: Roses should be shown with stems or without stems — never with thorns, and typically without prominent leaves.',
     level: 1,
     section: 'foundations',
   },
@@ -177,6 +179,8 @@ export const level1Slides: TeachingSlide[] = [
     originalImage: 'level-1/11-therosegold.PNG',
     reimaginedImage: 'level-1/11-therosegold.PNG',
     final: true,
+    imageNote:
+      'Rose illustration guideline: Roses are typically depicted with a bloom and stem (or no stem). Leaves should be minimal or absent. Thorns must never be shown — the rose in this practice is a pure energetic instrument without thorns.',
     level: 1,
     section: 'foundations',
   },


### PR DESCRIPTION
## Summary
Updated the rose 3D model rendering and teaching slides to align with the practice's symbolic representation of the rose as a pure energetic instrument without thorns or prominent leaves.

## Key Changes

**RoseModel.tsx:**
- Removed the `leafMaterial` definition as leaves are no longer rendered
- Added visibility logic to hide model children with "thorn" or "leaf" in their names
- Simplified material assignment by removing the leaf material case
- Added explanatory comments documenting why thorns and leaves are hidden

**teaching-slides.ts:**
- Added `imageNote` field to two foundational rose slides (slides 1 and 11) with illustration guidelines
- Guidelines specify that roses should be shown with or without stems, but never with thorns and typically without prominent leaves
- Emphasizes the rose as a "pure energetic instrument without thorns"

## Implementation Details
The changes use a straightforward approach: model children are checked by name during initialization, and those matching "thorn" or "leaf" patterns are hidden before material assignment occurs. This preserves the model structure while controlling visibility, allowing for easy toggling if needed in the future.

https://claude.ai/code/session_01Ndi7YCwnporK6FmFpAokWf