### PR TITLE
Update scope document: v1.5 with clarified ownership and engagement terms

### DIFF
--- a/docs/brand/scope-of-work-and-proposal.md
+++ b/docs/brand/scope-of-work-and-proposal.md
@@ -417,7 +417,7 @@ Larger platform features (Full Payment Page, Blog, YouTube integration, customer
 - **Ownership & IP** -- All assets -- platform code, brand assets, and content -- are owned by ROSES OS.
 - **Ongoing Maintenance** -- The platform requires ongoing technical maintenance, hosting, updates, and security. How is this accounted for?
 - **Licensing** -- Are there licensing considerations for the teaching content, brand assets, or platform code?
-- **Repository Visibility** -- The ROSES OS codebase is currently hosted as a public repository at [github.com/Light-Brands/roses-os](https://github.com/Light-Brands/roses-os). Should it remain public or be made private? If made private, each team member who needs access will need a GitHub account (free tier). To get access: (1) Sign up at [github.com](https://github.com) (2) Share your GitHub username so you can be invited as a collaborator to the repository.
+- **Repository Visibility** -- The ROSES OS codebase is currently hosted as a public repository at [github.com/Light-Brands-AI/roses-os](https://github.com/Light-Brands-AI/roses-os). Should it remain public or be made private? If made private, each team member who needs access will need a GitHub account (free tier). To get access: (1) Sign up at [github.com](https://github.com) (2) Share your GitHub username so you can be invited as a collaborator to the repository.
 
 ---
 
@@ -450,7 +450,7 @@ The following conditions apply to the use of ROSES OS content:
 
 ### Platform & Infrastructure
 
-The digital platform, codebase, design system, and technical infrastructure of ROSES OS are owned by **ROSES OS**. These assets are not included in the teaching-use provisions above.
+All assets created and delivered -- including the digital platform, codebase, design system, content, brand assets, and technical infrastructure -- are owned by **ROSES OS**. The techniques, processes, and technical methodologies used to create the platform are proprietary to **LIGHT BRANDS AI**. Platform and infrastructure assets are not included in the teaching-use provisions above.
 
 ### A Living Agreement
 
@@ -468,7 +468,7 @@ For context on the technical foundation that supports everything above:
 
 | Infrastructure | Details |
 |----------------|---------|
-| **Repository** | GitHub (Light-Brands/roses-os) -- version-controlled, 160+ commits, 58+ merged PRs |
+| **Repository** | GitHub (Light-Brands-AI/roses-os) -- version-controlled, 160+ commits, 58+ merged PRs |
 | **Hosting** | Production-ready Next.js deployment |
 | **Database** | Supabase (PostgreSQL) with SSR auth |
 | **AI Services** | Google GenAI integration |


### PR DESCRIPTION
## Summary
Updated the Scope of Work and Proposal document (v1.5) to clarify project engagement structure, ownership terms, and repository information. Changes reflect a shift toward more flexible, discussion-based project scoping while establishing clear asset ownership for ROSES OS.

## Key Changes

- **Version bump**: Updated from v1.4 to v1.5 (dated March 11, 2026)

- **Phase 3 engagement language**: Revised project milestone descriptions to emphasize collaborative discussion and flexible scoping rather than fixed, independent engagements
  - Changed from "scoped as a standalone engagement" to "each with defined deliverables"
  - Updated closing language to reflect open conversation about timing and approach as priorities emerge

- **Ownership & IP clarification**: Added explicit statement that all assets (platform code, brand assets, content) are owned by ROSES OS

- **Repository URL updates**: Changed GitHub organization from `Light-Brands` to `Light-Brands-AI` across all references (3 instances)

- **Platform ownership statement**: Expanded and clarified the Platform & Infrastructure section to distinguish between:
  - Assets owned by ROSES OS (digital platform, codebase, design system, content, brand assets, infrastructure)
  - Proprietary methodologies owned by LIGHT BRANDS AI

- **Future Platform Builds table**: Simplified dependency descriptions by removing "Can be built independently" language from 5 entries, streamlining the table while maintaining essential technical dependencies

- **Creative/Art Director role**: Reframed from a suggestion to "open for discussion," removing prescriptive language about role transition

## Notable Details
All changes maintain document structure and formatting while clarifying business terms and technical ownership. No functional platform changes—this is documentation-only.

https://claude.ai/code/session_019823CmWVY8xQzw2WcWiRmZ