### PR TITLE
Teacher's Aid PDF: restore original cover images on pages 1, 4, 22, 25

### DIFF
--- a/scripts/pdf-manuals/roses-teachers-aid-el.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-el.html
@@ -406,7 +406,7 @@
       <div class="s28"></div>
 
       <div class="img-circle" style="width: 320px; height: 320px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Sacred Rose">
+        <img src="images/manual-l1-cover.png" alt="Sacred Rose">
       </div>
       <div class="s32"></div>
 
@@ -554,7 +554,7 @@
       <div class="line-c"></div>
       <div class="s32"></div>
       <div class="img-circle" style="width: 200px; height: 200px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Rose">
+        <img src="images/manual-l1-cover.png" alt="Rose">
       </div>
     </div>
 
@@ -1410,7 +1410,7 @@
       <div class="line-c"></div>
       <div class="s32"></div>
       <div class="img-circle" style="width: 200px; height: 200px;">
-        <img src="images/level-3/39-analyzer.PNG" alt="The Analyzer">
+        <img src="images/manual-l3-cover-l3.png" alt="Sacred Rose">
       </div>
     </div>
 
@@ -1529,7 +1529,7 @@
     <div class="inner" style="align-items: center; justify-content: center; text-align: center;">
 
       <div class="img-circle" style="width: 180px; height: 180px; margin-bottom: 36px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Rose">
+        <img src="images/manual-l1-cover.png" alt="Rose">
       </div>
 
       <p style="font-family: var(--font-serif); font-size: 15pt; font-weight: 300; font-style: italic; color: var(--rose-700); line-height: 1.65; max-width: 4.2in;">

--- a/scripts/pdf-manuals/roses-teachers-aid-es.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-es.html
@@ -406,7 +406,7 @@
       <div class="s28"></div>
 
       <div class="img-circle" style="width: 320px; height: 320px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Sacred Rose">
+        <img src="images/manual-l1-cover.png" alt="Sacred Rose">
       </div>
       <div class="s32"></div>
 
@@ -554,7 +554,7 @@
       <div class="line-c"></div>
       <div class="s32"></div>
       <div class="img-circle" style="width: 200px; height: 200px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Rose">
+        <img src="images/manual-l1-cover.png" alt="Rose">
       </div>
     </div>
 
@@ -1410,7 +1410,7 @@
       <div class="line-c"></div>
       <div class="s32"></div>
       <div class="img-circle" style="width: 200px; height: 200px;">
-        <img src="images/level-3/39-analyzer.PNG" alt="The Analyzer">
+        <img src="images/manual-l3-cover-l3.png" alt="Sacred Rose">
       </div>
     </div>
 
@@ -1529,7 +1529,7 @@ También podemos cortar los lazos cuando la relación no ha terminado, pero sent
     <div class="inner" style="align-items: center; justify-content: center; text-align: center;">
 
       <div class="img-circle" style="width: 180px; height: 180px; margin-bottom: 36px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Rose">
+        <img src="images/manual-l1-cover.png" alt="Rose">
       </div>
 
       <p style="font-family: var(--font-serif); font-size: 15pt; font-weight: 300; font-style: italic; color: var(--rose-700); line-height: 1.65; max-width: 4.2in;">

--- a/scripts/pdf-manuals/roses-teachers-aid-pt.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-pt.html
@@ -406,7 +406,7 @@
       <div class="s28"></div>
 
       <div class="img-circle" style="width: 320px; height: 320px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Sacred Rose">
+        <img src="images/manual-l1-cover.png" alt="Sacred Rose">
       </div>
       <div class="s32"></div>
 
@@ -554,7 +554,7 @@
       <div class="line-c"></div>
       <div class="s32"></div>
       <div class="img-circle" style="width: 200px; height: 200px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Rose">
+        <img src="images/manual-l1-cover.png" alt="Rose">
       </div>
     </div>
 
@@ -1410,7 +1410,7 @@
       <div class="line-c"></div>
       <div class="s32"></div>
       <div class="img-circle" style="width: 200px; height: 200px;">
-        <img src="images/level-3/39-analyzer.PNG" alt="The Analyzer">
+        <img src="images/manual-l3-cover-l3.png" alt="Sacred Rose">
       </div>
     </div>
 
@@ -1529,7 +1529,7 @@ Também podemos cortar os laços quando o relacionamento não terminou, mas sent
     <div class="inner" style="align-items: center; justify-content: center; text-align: center;">
 
       <div class="img-circle" style="width: 180px; height: 180px; margin-bottom: 36px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Rose">
+        <img src="images/manual-l1-cover.png" alt="Rose">
       </div>
 
       <p style="font-family: var(--font-serif); font-size: 15pt; font-weight: 300; font-style: italic; color: var(--rose-700); line-height: 1.65; max-width: 4.2in;">

--- a/scripts/pdf-manuals/roses-teachers-aid.html
+++ b/scripts/pdf-manuals/roses-teachers-aid.html
@@ -406,7 +406,7 @@
       <div class="s28"></div>
 
       <div class="img-circle" style="width: 320px; height: 320px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Sacred Rose">
+        <img src="images/manual-l1-cover.png" alt="Sacred Rose">
       </div>
       <div class="s32"></div>
 
@@ -554,7 +554,7 @@
       <div class="line-c"></div>
       <div class="s32"></div>
       <div class="img-circle" style="width: 200px; height: 200px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Rose">
+        <img src="images/manual-l1-cover.png" alt="Rose">
       </div>
     </div>
 
@@ -1398,7 +1398,7 @@
       <div class="line-c"></div>
       <div class="s32"></div>
       <div class="img-circle" style="width: 200px; height: 200px;">
-        <img src="images/level-3/39-analyzer.PNG" alt="The Analyzer">
+        <img src="images/manual-l3-cover-l3.png" alt="Sacred Rose">
       </div>
     </div>
 
@@ -1507,7 +1507,7 @@
     <div class="inner" style="align-items: center; justify-content: center; text-align: center;">
 
       <div class="img-circle" style="width: 180px; height: 180px; margin-bottom: 36px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="Rose">
+        <img src="images/manual-l1-cover.png" alt="Rose">
       </div>
 
       <p style="font-family: var(--font-serif); font-size: 15pt; font-weight: 300; font-style: italic; color: var(--rose-700); line-height: 1.65; max-width: 4.2in;">


### PR DESCRIPTION
Replace blue watercolor rose with original mandala cover images on cover,
divider, and closing pages across all language versions (EN, ES, PT, EL).

https://claude.ai/code/session_01Ewjima9pxGMsaTzhQbRAMm