### PR TITLE
Update manual credits and separate Level 2 manual

### DIFF
--- a/scripts/pdf-manuals/roses-manual-1.html
+++ b/scripts/pdf-manuals/roses-manual-1.html
@@ -348,7 +348,7 @@
         ROSES OS<br><br>
         <span style="font-size: 7.5pt; color: var(--rose-400);">
           Original illustrations: Saraswati Noemi, Cecilia Lynch &amp; Drica Voivodic<br>
-          Updated visuals &amp; formatting: Jennifer Lawless &nbsp;·&nbsp; Editor: Dara Ayoub
+          Editor: Dara Ayoub &nbsp;·&nbsp; Design: Jennifer Lawless
         </span>
       </div>
       <div class="s16"></div>
@@ -953,7 +953,7 @@
       <div style="font-family: var(--font-sans); font-size: 7pt; color: var(--rose-400); line-height: 1.8; letter-spacing: 0.03em;">
         Teachings by Angelina Ataíde &nbsp;·&nbsp; ROSES OS<br>
         Original illustrations: Saraswati Noemi, Cecilia Lynch &amp; Drica Voivodic<br>
-        Updated visuals &amp; formatting: Jennifer Lawless &nbsp;·&nbsp; Editor: Dara Ayoub
+        Editor: Dara Ayoub &nbsp;·&nbsp; Design: Jennifer Lawless
       </div>
       <div class="s20"></div>
       <div style="font-family: var(--font-sans); font-size: 6.5pt; letter-spacing: 0.25em; text-transform: uppercase; color: var(--gold);">ROSES OS</div>

--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -331,7 +331,7 @@
         ROSES OS<br><br>
         <span style="font-size: 7.5pt; color: var(--rose-400);">
           Illustrations: Saraswati Noemi, Cecilia Lynch &amp; Drica Voivodic<br>
-          Updated visuals &amp; formatting: Jennifer Lawless &nbsp;·&nbsp; Editor: Dara Ayoub
+          Editor: Dara Ayoub &nbsp;·&nbsp; Design: Jennifer Lawless
         </span>
       </div>
       <div class="s16"></div>
@@ -733,7 +733,7 @@
       <div style="font-family: var(--font-sans); font-size: 7pt; color: var(--rose-400); line-height: 1.8; letter-spacing: 0.03em;">
         Teachings by Angelina Ataíde<br>
         Illustrations: Saraswati Noemi, Cecilia Lynch &amp; Drica Voivodic<br>
-        Updated visuals &amp; formatting: Jennifer Lawless &nbsp;·&nbsp; Editor: Dara Ayoub
+        Editor: Dara Ayoub &nbsp;·&nbsp; Design: Jennifer Lawless
       </div>
       <div class="s20"></div>
       <div style="font-family: var(--font-sans); font-size: 6.5pt; letter-spacing: 0.25em; text-transform: uppercase; color: var(--gold);">ROSES OS</div>


### PR DESCRIPTION
## Summary
This PR separates the combined Rose Meditation Level 1 & 2 manual into individual manuals and updates credit attributions across all manual files for consistency and clarity.

## Key Changes
- **Manual Configuration**: Updated `build-manuals.ts` to reference a separate Level 2 manual (`roses-manual-2.html`) with its own ID (`2`) instead of the combined Level 1 & 2 manual
- **Credit Attribution Updates**: Standardized credit lines across all three manual files:
  - Changed "Updated visuals & formatting: Jennifer Lawless · Editor: Dara Ayoub" to "Editor: Dara Ayoub · Design: Jennifer Lawless"
  - For Level 3 manual, updated to "Editor & Translation: Dara Ayoub · Design: Jennifer Lawless"
  - Applied changes consistently to both cover pages and content sections in each manual
- **File Organization**: Renamed/created `roses-manual-2.html` as a standalone Level 2 manual file with updated credits

## Notable Details
- All credit updates maintain the same contributors but reorder and relabel roles for clarity
- Changes applied to multiple locations within each HTML file (cover pages and content sections)
- The separation allows for independent versioning and distribution of Level 2 content

https://claude.ai/code/session_01Ct8djcyZtDg4gLro8mDLxb