### PR TITLE
Refactor Rose practice layouts to stack vertically instead of side-by-side

### DIFF
--- a/scripts/pdf-manuals/roses-manual-1.html
+++ b/scripts/pdf-manuals/roses-manual-1.html
@@ -747,29 +747,32 @@
       </div>
       <div class="s12"></div>
 
-      <div class="cols">
-        <div style="text-align: center;">
-          <div class="img-center" style="justify-content: center;">
-            <img src="images/level-1/13-cleansing-rose-reimagined.png" alt="Cleansing Rose" style="width: 180px; border-radius: 12px; outline: 0.5px solid var(--rose-200);">
-          </div>
-          <div class="s8"></div>
-          <h4 class="h-sm">Cleansing Rose</h4>
-          <div class="s4"></div>
-          <p class="body-sm">Create a Rose in a high-vibration color, grounded in front of you, outside your Aura. Place any uncomfortable situation on it — thoughts, people, events, fears. Intend for the Rose to suck in energy like a vacuum.</p>
-          <div class="s4"></div>
-          <p class="body-sm">Explode the Rose out of your Aura to cleanse the energy and raise the vibration. Create new Roses as many times as required.</p>
+      <!-- Cleansing Rose — stacked above Recovery -->
+      <div style="text-align: center;">
+        <div class="img-center" style="justify-content: center;">
+          <img src="images/level-1/13-cleansing-rose-reimagined.png" alt="Cleansing Rose" style="width: 200px; border-radius: 12px; outline: 0.5px solid var(--rose-200);">
         </div>
-        <div style="text-align: center;">
-          <div class="img-center" style="justify-content: center;">
-            <img src="images/level-1/14-energy-recovery-background.png" alt="Recovery Rose" style="width: 200px; border-radius: 12px; outline: 0.5px solid var(--rose-200);">
-          </div>
-          <div class="s8"></div>
-          <h4 class="h-sm">Recovery Rose</h4>
-          <div class="s4"></div>
-          <p class="body-sm">Create another Rose, grounded outside your Aura, and call your energy back. The Rose attracts your energy scattered throughout the universe like a magnet.</p>
-          <div class="s4"></div>
-          <p class="body-sm">Explode the Rose out of your Aura, and receive your high vibrational and purified energy back to you.</p>
+        <div class="s8"></div>
+        <h4 class="h-sm">Cleansing Rose</h4>
+        <div class="s4"></div>
+        <p class="body-sm">Create a Rose in a high-vibration color, grounded in front of you, outside your Aura. Place any uncomfortable situation on it — thoughts, people, events, fears. Intend for the Rose to suck in energy like a vacuum.</p>
+        <div class="s4"></div>
+        <p class="body-sm">Explode the Rose out of your Aura to cleanse the energy and raise the vibration. Create new Roses as many times as required.</p>
+      </div>
+
+      <div class="s12"></div>
+
+      <!-- Recovery Rose -->
+      <div style="text-align: center;">
+        <div class="img-center" style="justify-content: center;">
+          <img src="images/level-1/14-energy-recovery-background.png" alt="Recovery Rose" style="width: 200px; border-radius: 12px; outline: 0.5px solid var(--rose-200);">
         </div>
+        <div class="s8"></div>
+        <h4 class="h-sm">Recovery Rose</h4>
+        <div class="s4"></div>
+        <p class="body-sm">Create another Rose, grounded outside your Aura, and call your energy back. The Rose attracts your energy scattered throughout the universe like a magnet.</p>
+        <div class="s4"></div>
+        <p class="body-sm">Explode the Rose out of your Aura, and receive your high vibrational and purified energy back to you.</p>
       </div>
 
       <div class="s12"></div>

--- a/scripts/pdf-manuals/roses-teachers-aid-el.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-el.html
@@ -733,23 +733,24 @@
     <div class="ck ck-bl"></div><div class="ck ck-br"></div>
 
     <div class="inner">
-      <div class="cols" style="gap: 16px;">
-        <div class="slide-card">
-          <div class="slide-badge">13</div>
-          <div class="slide-title">Τριαντάφυλλο Καθαρισμού</div>
-          <div class="img-full" style="width: 60%; max-width: 240px;">
-            <img src="images/manual-l12-cleansing-recovery.png" alt="Cleansing Rose">
-          </div>
-          <p class="slide-text">Το Τριαντάφυλλο Καθαρισμού τοποθετείται έξω από την αύρα. Χρησιμοποιείται για να απορροφήσει και να μετατρέψει ξένη ή στάσιμη ενέργεια μέσα από το πεδίο σας. Ενέργεια που δεν σας ανήκει — από άλλους</p>
+      <div class="slide-card">
+        <div class="slide-badge">13</div>
+        <div class="slide-title">Τριαντάφυλλο Καθαρισμού</div>
+        <div class="img-full" style="width: 60%; max-width: 240px;">
+          <img src="images/manual-l12-cleansing-recovery.png" alt="Cleansing Rose">
         </div>
-        <div class="slide-card">
-          <div class="slide-badge">14</div>
-          <div class="slide-title">Ενεργειακή Ανάκτηση Κάθε Τσάκρα</div>
-          <div class="img-full" style="width: 60%; max-width: 240px;">
-            <img src="images/teaching-energy-recovery-rose.png" alt="Energy Recovery">
-          </div>
-          <p class="slide-text">Μετά τον καθαρισμό, το Τριαντάφυλλο χρησιμοποιείται για να ανακτήσει τη δική σας ενέργεια που αφέθηκε ή πάρθηκε από άλλους. Το Τριαντάφυλλο στέλνεται ως όργανο για να συγκεντρώσει και να επιστρέψει τη δική σας ζωτική ενέργεια σε κάθε τσάκρα, αποκαθιστώντας πληρότητα και κυριαρχία σε κάθε ενεργειακό κέντρο. The Rose gathers and returns your life-force energy to each chakra, restoring fullness and sovereignty.</p>
+        <p class="slide-text">Το Τριαντάφυλλο Καθαρισμού τοποθετείται έξω από την αύρα. Χρησιμοποιείται για να απορροφήσει και να μετατρέψει ξένη ή στάσιμη ενέργεια μέσα από το πεδίο σας. Ενέργεια που δεν σας ανήκει — από άλλους</p>
+      </div>
+
+      <div class="s16"></div>
+
+      <div class="slide-card">
+        <div class="slide-badge">14</div>
+        <div class="slide-title">Ενεργειακή Ανάκτηση Κάθε Τσάκρα</div>
+        <div class="img-full" style="width: 60%; max-width: 240px;">
+          <img src="images/teaching-energy-recovery-rose.png" alt="Energy Recovery">
         </div>
+        <p class="slide-text">Μετά τον καθαρισμό, το Τριαντάφυλλο χρησιμοποιείται για να ανακτήσει τη δική σας ενέργεια που αφέθηκε ή πάρθηκε από άλλους. Το Τριαντάφυλλο στέλνεται ως όργανο για να συγκεντρώσει και να επιστρέψει τη δική σας ζωτική ενέργεια σε κάθε τσάκρα, αποκαθιστώντας πληρότητα και κυριαρχία σε κάθε ενεργειακό κέντρο. The Rose gathers and returns your life-force energy to each chakra, restoring fullness and sovereignty.</p>
       </div>
 
       <div class="s16"></div>

--- a/scripts/pdf-manuals/roses-teachers-aid-es.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-es.html
@@ -734,23 +734,24 @@
     <div class="ck ck-bl"></div><div class="ck ck-br"></div>
 
     <div class="inner">
-      <div class="cols" style="gap: 16px;">
-        <div class="slide-card">
-          <div class="slide-badge">13</div>
-          <div class="slide-title">Rosa de Limpieza</div>
-          <div class="img-full" style="width: 60%; max-width: 240px;">
-            <img src="images/manual-l12-cleansing-recovery.png" alt="Cleansing Rose">
-          </div>
-          <p class="slide-text">La Rosa de Limpieza se coloca fuera del aura. Se utiliza para absorber y transmutar energía ajena o estancada de su campo. La energía que no le pertenece — de otras personas, ambientes o experiencias</p>
+      <div class="slide-card">
+        <div class="slide-badge">13</div>
+        <div class="slide-title">Rosa de Limpieza</div>
+        <div class="img-full" style="width: 60%; max-width: 240px;">
+          <img src="images/manual-l12-cleansing-recovery.png" alt="Cleansing Rose">
         </div>
-        <div class="slide-card">
-          <div class="slide-badge">14</div>
-          <div class="slide-title">Recuperación Energética de Cada Chakra</div>
-          <div class="img-full" style="width: 60%; max-width: 240px;">
-            <img src="images/teaching-energy-recovery-rose.png" alt="Energy Recovery">
-          </div>
-          <p class="slide-text">Después de la limpieza, la Rosa se utiliza para recuperar su propia energía que ha sido dejada o tomada por otros. La Rosa es enviada como un instrumento para reunir y devolver su propia energía vital a cada chakra, restaurando plenitud y soberanía a cada centro energético. The Rose gathers and returns your life-force energy to each chakra, restoring fullness and sovereignty.</p>
+        <p class="slide-text">La Rosa de Limpieza se coloca fuera del aura. Se utiliza para absorber y transmutar energía ajena o estancada de su campo. La energía que no le pertenece — de otras personas, ambientes o experiencias</p>
+      </div>
+
+      <div class="s16"></div>
+
+      <div class="slide-card">
+        <div class="slide-badge">14</div>
+        <div class="slide-title">Recuperación Energética de Cada Chakra</div>
+        <div class="img-full" style="width: 60%; max-width: 240px;">
+          <img src="images/teaching-energy-recovery-rose.png" alt="Energy Recovery">
         </div>
+        <p class="slide-text">Después de la limpieza, la Rosa se utiliza para recuperar su propia energía que ha sido dejada o tomada por otros. La Rosa es enviada como un instrumento para reunir y devolver su propia energía vital a cada chakra, restaurando plenitud y soberanía a cada centro energético. The Rose gathers and returns your life-force energy to each chakra, restoring fullness and sovereignty.</p>
       </div>
 
       <div class="s16"></div>

--- a/scripts/pdf-manuals/roses-teachers-aid-pt.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-pt.html
@@ -733,23 +733,24 @@
     <div class="ck ck-bl"></div><div class="ck ck-br"></div>
 
     <div class="inner">
-      <div class="cols" style="gap: 16px;">
-        <div class="slide-card">
-          <div class="slide-badge">13</div>
-          <div class="slide-title">Rosa de Limpeza</div>
-          <div class="img-full" style="width: 60%; max-width: 240px;">
-            <img src="images/manual-l12-cleansing-recovery.png" alt="Cleansing Rose">
-          </div>
-          <p class="slide-text">A Rosa de Limpeza é colocada fora da aura. Ela é usada para absorver e transmutar energia estranha ou estagnada do seu campo. Energia que não pertence a você — de outras pessoas, ambientes ou</p>
+      <div class="slide-card">
+        <div class="slide-badge">13</div>
+        <div class="slide-title">Rosa de Limpeza</div>
+        <div class="img-full" style="width: 60%; max-width: 240px;">
+          <img src="images/manual-l12-cleansing-recovery.png" alt="Cleansing Rose">
         </div>
-        <div class="slide-card">
-          <div class="slide-badge">14</div>
-          <div class="slide-title">Recuperação Energética de Cada Chakra</div>
-          <div class="img-full" style="width: 60%; max-width: 240px;">
-            <img src="images/teaching-energy-recovery-rose.png" alt="Energy Recovery">
-          </div>
-          <p class="slide-text">Após a limpeza, a Rosa é usada para recuperar sua própria energia que foi deixada ou tomada por outros. A Rosa é enviada como um instrumento para reunir e devolver sua própria energia vital a cada chakra, restaurando plenitude e soberania a cada centro energético. The Rose gathers and returns your life-force energy to each chakra, restoring fullness and sovereignty.</p>
+        <p class="slide-text">A Rosa de Limpeza é colocada fora da aura. Ela é usada para absorver e transmutar energia estranha ou estagnada do seu campo. Energia que não pertence a você — de outras pessoas, ambientes ou</p>
+      </div>
+
+      <div class="s16"></div>
+
+      <div class="slide-card">
+        <div class="slide-badge">14</div>
+        <div class="slide-title">Recuperação Energética de Cada Chakra</div>
+        <div class="img-full" style="width: 60%; max-width: 240px;">
+          <img src="images/teaching-energy-recovery-rose.png" alt="Energy Recovery">
         </div>
+        <p class="slide-text">Após a limpeza, a Rosa é usada para recuperar sua própria energia que foi deixada ou tomada por outros. A Rosa é enviada como um instrumento para reunir e devolver sua própria energia vital a cada chakra, restaurando plenitude e soberania a cada centro energético. The Rose gathers and returns your life-force energy to each chakra, restoring fullness and sovereignty.</p>
       </div>
 
       <div class="s16"></div>

--- a/scripts/pdf-manuals/roses-teachers-aid.html
+++ b/scripts/pdf-manuals/roses-teachers-aid.html
@@ -730,23 +730,24 @@
     <div class="ck ck-bl"></div><div class="ck ck-br"></div>
 
     <div class="inner">
-      <div class="cols" style="gap: 16px;">
-        <div class="slide-card">
-          <div class="slide-badge">13</div>
-          <div class="slide-title">Cleansing Rose</div>
-          <div class="img-full" style="width: 60%; max-width: 240px;">
-            <img src="images/manual-l12-cleansing-recovery.png" alt="Cleansing Rose">
-          </div>
-          <p class="slide-text">The Cleansing Rose is placed outside of the aura. It absorbs and transmutes foreign or stagnant energy from within your field. Energy that does not belong to you is drawn out and neutralized.</p>
+      <div class="slide-card">
+        <div class="slide-badge">13</div>
+        <div class="slide-title">Cleansing Rose</div>
+        <div class="img-full" style="width: 60%; max-width: 240px;">
+          <img src="images/manual-l12-cleansing-recovery.png" alt="Cleansing Rose">
         </div>
-        <div class="slide-card">
-          <div class="slide-badge">14</div>
-          <div class="slide-title">Energy Recovery of Each Chakra</div>
-          <div class="img-full" style="width: 60%; max-width: 240px;">
-            <img src="images/teaching-energy-recovery-rose.png" alt="Energy Recovery">
-          </div>
-          <p class="slide-text">After cleansing, the Rose is used to recover your own energy that has been left in or taken by others. The Rose gathers and returns your life-force energy to each chakra, restoring fullness and sovereignty.</p>
+        <p class="slide-text">The Cleansing Rose is placed outside of the aura. It absorbs and transmutes foreign or stagnant energy from within your field. Energy that does not belong to you is drawn out and neutralized.</p>
+      </div>
+
+      <div class="s16"></div>
+
+      <div class="slide-card">
+        <div class="slide-badge">14</div>
+        <div class="slide-title">Energy Recovery of Each Chakra</div>
+        <div class="img-full" style="width: 60%; max-width: 240px;">
+          <img src="images/teaching-energy-recovery-rose.png" alt="Energy Recovery">
         </div>
+        <p class="slide-text">After cleansing, the Rose is used to recover your own energy that has been left in or taken by others. The Rose gathers and returns your life-force energy to each chakra, restoring fullness and sovereignty.</p>
       </div>
 
       <div class="s16"></div>


### PR DESCRIPTION
## Summary
Restructured the layout of Cleansing Rose and Recovery Rose practice cards across multiple manual files to display vertically stacked instead of in a horizontal side-by-side grid layout. This improves readability and responsive design.

## Key Changes
- **roses-manual-1.html**: Removed `.cols` wrapper and separated the two Rose practices into individual centered divs with a spacing divider (`s12`) between them. Updated image width from 180px to 200px for consistency.
- **roses-teachers-aid.html** (English): Converted from horizontal `.cols` grid layout to individual `.slide-card` blocks with `s16` spacing divider between Cleansing Rose and Recovery Rose sections.
- **roses-teachers-aid-el.html** (Greek): Applied same vertical stacking refactor to Greek language version.
- **roses-teachers-aid-es.html** (Spanish): Applied same vertical stacking refactor to Spanish language version.
- **roses-teachers-aid-pt.html** (Portuguese): Applied same vertical stacking refactor to Portuguese language version.

## Implementation Details
- Removed `<div class="cols" style="gap: 16px;">` wrapper elements
- Each Rose practice now has its own dedicated container with `text-align: center;`
- Added HTML comments for clarity (e.g., `<!-- Cleansing Rose — stacked above Recovery -->`)
- Maintained consistent spacing using existing spacing utility classes (`s8`, `s4`, `s12`, `s16`)
- All content and styling preserved; only layout structure changed

https://claude.ai/code/session_01HzW83BonnZLTAV13EmCSmF