### PR TITLE
Refactor Golden Sticky Roses section into two-page layout

### DIFF
--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -941,7 +941,7 @@
       <!-- Third Eye Chakra -->
       <div class="chakra-card">
         <div class="chakra-img">
-          <img src="images/teaching-third-eye-chakra.png" alt="Third Eye Chakra">
+          <img src="images/level-2/30-third-eye-chakra.jpeg" alt="Third Eye Chakra">
         </div>
         <div class="chakra-info">
           <div class="chakra-name" style="color: #4F46E5;">Third Eye Chakra</div>
@@ -1149,7 +1149,7 @@
   </div>
 
   <!-- =====================================================
-       PAGE 13 — GOLDEN STICKY ROSES (slides 35-38)
+       PAGE 13 — GOLDEN STICKY ROSES Phase 1 & 2 (slides 35-36)
        ===================================================== -->
   <div class="page">
     <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
@@ -1160,42 +1160,27 @@
       <div class="s8"></div>
       <h2 class="h-lg">Golden Sticky Roses</h2>
       <div class="s8"></div>
+      <p class="body" style="margin-bottom: 8px;">Golden sticky roses are used for deep energetic cleansing of the body, placed in four progressive phases:</p>
 
-      <p class="body" style="margin-bottom: 4px;">Golden sticky roses are used for deep energetic cleansing of the body, placed in four progressive phases:</p>
+      <!-- Phase 1 -->
+      <div style="display: flex; gap: 16px; align-items: flex-start; margin-bottom: 16px;">
+        <div style="flex: 0 0 48%; border-radius: 12px; overflow: hidden;">
+          <img src="images/level-2/35-golden-sticky-1.jpg" alt="Golden Sticky Rose — Phase 1: Chakra Placement" style="width: 100%; height: auto; display: block; border-radius: 12px;">
+        </div>
+        <div style="flex: 1;">
+          <p class="h-sm" style="font-size: 10pt; margin-bottom: 4px; color: var(--gold);">Phase 1 — Chakra Placement</p>
+          <p class="body" style="font-size: 9pt; line-height: 1.5;">Golden sticky roses are placed on each of the seven chakras, drawing out foreign energy lodged in the energy centers. Each rose adheres to the chakra and begins to absorb and extract energies that do not belong to you — clearing the way for deeper purification.</p>
+        </div>
+      </div>
 
-      <!-- 2x2 grid of Golden Sticky Rose phases -->
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 0 auto; width: 92%;">
-        <div style="text-align: center;">
-          <div style="border-radius: 12px; overflow: hidden;">
-            <img src="images/level-2/35-golden-sticky-1.jpg" alt="Golden Sticky Rose — Phase 1: Chakra Placement" style="width: 100%; height: auto; display: block; border-radius: 12px;">
-          </div>
-          <div class="s4"></div>
-          <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 1px;">Phase 1 — Chakra Placement</p>
-          <p class="body-sm" style="font-size: 6.5pt; line-height: 1.35;">Placed on each of the seven chakras, drawing out foreign energy lodged in the energy centers.</p>
+      <!-- Phase 2 -->
+      <div style="display: flex; gap: 16px; align-items: flex-start;">
+        <div style="flex: 0 0 48%; border-radius: 12px; overflow: hidden;">
+          <img src="images/level-2/36-golden-sticky-2.jpg" alt="Golden Sticky Rose — Phase 2: Body Placement" style="width: 100%; height: auto; display: block; border-radius: 12px;">
         </div>
-        <div style="text-align: center;">
-          <div style="border-radius: 12px; overflow: hidden;">
-            <img src="images/level-2/36-golden-sticky-2.jpg" alt="Golden Sticky Rose — Phase 2: Body Placement" style="width: 100%; height: auto; display: block; border-radius: 12px;">
-          </div>
-          <div class="s4"></div>
-          <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 1px;">Phase 2 — Body Placement</p>
-          <p class="body-sm" style="font-size: 6.5pt; line-height: 1.35;">Placed at joints and extremities — shoulders, elbows, wrists, hands, hips, knees, ankles, feet.</p>
-        </div>
-        <div style="text-align: center;">
-          <div style="border-radius: 12px; overflow: hidden;">
-            <img src="images/level-2/37-golden-sticky-3.jpg" alt="Golden Sticky Rose — Phase 3: Full Body Coverage" style="width: 100%; height: auto; display: block; border-radius: 12px;">
-          </div>
-          <div class="s4"></div>
-          <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 1px;">Phase 3 — Full Body Coverage</p>
-          <p class="body-sm" style="font-size: 6.5pt; line-height: 1.35;">Placed throughout the entire body — torso, limbs, and all remaining areas for thorough cleansing.</p>
-        </div>
-        <div style="text-align: center;">
-          <div style="border-radius: 12px; overflow: hidden;">
-            <img src="images/level-2/38-golden-sticky-4.jpg" alt="Golden Sticky Rose — Phase 4: Integration" style="width: 100%; height: auto; display: block; border-radius: 12px;">
-          </div>
-          <div class="s4"></div>
-          <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 1px;">Phase 4 — Integration</p>
-          <p class="body-sm" style="font-size: 6.5pt; line-height: 1.35;">A large Golden Rose appears above. All foreign energy is released and the body is bathed in golden light.</p>
+        <div style="flex: 1;">
+          <p class="h-sm" style="font-size: 10pt; margin-bottom: 4px; color: var(--gold);">Phase 2 — Body Placement</p>
+          <p class="body" style="font-size: 9pt; line-height: 1.5;">Golden sticky roses are placed at the joints and extremities of the body — shoulders, elbows, wrists, hands, hips, knees, ankles, feet — drawing out foreign energy stored in the physical body. These areas often hold tension and accumulated energies from daily interactions.</p>
         </div>
       </div>
     </div>
@@ -1204,7 +1189,51 @@
   </div>
 
   <!-- =====================================================
-       PAGE 14 — ELEMENTS SUMMARY (Level 2)
+       PAGE 14 — GOLDEN STICKY ROSES Phase 3 & 4 (slides 37-38)
+       ===================================================== -->
+  <div class="page">
+    <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
+    <div class="ck ck-bl"></div><div class="ck ck-br"></div>
+
+    <div class="inner">
+      <div class="label">Deep Cleansing</div>
+      <div class="s8"></div>
+      <h2 class="h-lg">Golden Sticky Roses <span style="font-weight: 300; font-size: 0.7em;">(continued)</span></h2>
+      <div class="s8"></div>
+
+      <!-- Phase 3 -->
+      <div style="display: flex; gap: 16px; align-items: flex-start; margin-bottom: 16px;">
+        <div style="flex: 0 0 48%; border-radius: 12px; overflow: hidden;">
+          <img src="images/level-2/37-golden-sticky-3.jpg" alt="Golden Sticky Rose — Phase 3: Full Body Coverage" style="width: 100%; height: auto; display: block; border-radius: 12px;">
+        </div>
+        <div style="flex: 1;">
+          <p class="h-sm" style="font-size: 10pt; margin-bottom: 4px; color: var(--gold);">Phase 3 — Full Body Coverage</p>
+          <p class="body" style="font-size: 9pt; line-height: 1.5;">Golden sticky roses are placed throughout the entire body — covering the torso, limbs, and all remaining areas — for a thorough, complete energetic cleansing. Every surface of the body is covered, ensuring no foreign energy remains hidden in any part of the physical or energetic form.</p>
+        </div>
+      </div>
+
+      <!-- Phase 4 -->
+      <div style="display: flex; gap: 16px; align-items: flex-start;">
+        <div style="flex: 0 0 48%; border-radius: 12px; overflow: hidden;">
+          <img src="images/level-2/38-golden-sticky-4.jpg" alt="Golden Sticky Rose — Phase 4: Integration" style="width: 100%; height: auto; display: block; border-radius: 12px;">
+        </div>
+        <div style="flex: 1;">
+          <p class="h-sm" style="font-size: 10pt; margin-bottom: 4px; color: var(--gold);">Phase 4 — Integration</p>
+          <p class="body" style="font-size: 9pt; line-height: 1.5;">After the golden sticky roses have done their work, a large Golden Rose appears above the head. All foreign energy gathered by the sticky roses is released upward, and the entire body is bathed in golden light — restoring, sealing, and integrating the energy body. This completes the deep cleansing cycle, leaving you purified and whole.</p>
+        </div>
+      </div>
+
+      <div class="s20"></div>
+      <div class="call-gold call">
+        <p style="color: var(--rose-800);">The four phases of Golden Sticky Roses work progressively — from the energy centers, to the joints, to the full body, and finally integration — ensuring a complete and thorough deep cleansing.</p>
+      </div>
+    </div>
+
+    <div class="pn"><span>14</span></div>
+  </div>
+
+  <!-- =====================================================
+       PAGE 15 — ELEMENTS SUMMARY (Level 2)
        ===================================================== -->
   <div class="page">
     <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
@@ -1262,11 +1291,11 @@
       </div>
     </div>
 
-    <div class="pn"><span>14</span></div>
+    <div class="pn"><span>15</span></div>
   </div>
 
   <!-- =====================================================
-       PAGE 15 — CLOSING
+       PAGE 16 — CLOSING
        ===================================================== -->
   <div class="page closing-bg">
     <div class="ck ck-tl"></div><div class="ck ck-tr"></div>


### PR DESCRIPTION
## Summary
Restructured the Golden Sticky Roses teaching content from a single 2x2 grid layout into a two-page spread, with improved typography, spacing, and content presentation.

## Key Changes
- **Layout Restructuring**: Converted the 4-phase grid layout into two separate pages (Pages 13-14), with Phases 1-2 on the first page and Phases 3-4 on the second page
- **Visual Design**: Changed from centered grid cards to side-by-side flex layouts with images on the left (48% width) and descriptive text on the right (flex: 1)
- **Typography Improvements**: 
  - Increased body text font size from 6.5pt to 9pt for better readability
  - Increased phase titles from 8.5pt to 10pt
  - Added gold color styling to phase titles using `color: var(--gold)`
  - Improved line-height from 1.35 to 1.5 for better text flow
- **Content Expansion**: Significantly expanded phase descriptions with more detailed explanations of each stage's purpose and effects
- **Added Integration**: Included a gold-highlighted callout box on Page 14 summarizing the four-phase progression
- **Image Update**: Changed Third Eye Chakra image source from `teaching-third-eye-chakra.png` to `level-2/30-third-eye-chakra.jpeg`
- **Page Numbering**: Updated page numbers to accommodate the new two-page layout (Elements Summary moved from Page 14 to Page 15, Closing moved from Page 15 to Page 16)
- **Section Header**: Updated comment to reflect "Phase 1 & 2" and "Phase 3 & 4" organization

## Implementation Details
- Maintained responsive image sizing with `width: 100%; height: auto`
- Preserved border-radius and overflow styling for consistent image presentation
- Used flexbox with `gap: 16px` for improved spacing between image and text
- Maintained consistent styling with existing design system variables

https://claude.ai/code/session_01YUEpcGHDRQpop7fME8zU9S