### PR TITLE
Consolidate Golden Sticky Roses content into single page layout

### DIFF
--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -1149,7 +1149,7 @@
   </div>
 
   <!-- =====================================================
-       PAGE 13 — GOLDEN STICKY ROSES Phase 1 & 2 (slides 35-36)
+       PAGE 13 — GOLDEN STICKY ROSES All 4 Phases (slides 35-38)
        ===================================================== -->
   <div class="page">
     <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
@@ -1159,29 +1159,53 @@
       <div class="label">Deep Cleansing</div>
       <div class="s8"></div>
       <h2 class="h-lg">Golden Sticky Roses</h2>
-      <div class="s8"></div>
-      <p class="body" style="margin-bottom: 8px;">Golden sticky roses are used for deep energetic cleansing of the body, placed in four progressive phases:</p>
+      <div style="height: 4px;"></div>
+      <p class="body" style="margin-bottom: 6px; font-size: 8.5pt;">Golden sticky roses are used for deep energetic cleansing of the body, placed in four progressive phases:</p>
 
-      <!-- Phase 1 -->
-      <div style="display: flex; gap: 16px; align-items: flex-start; margin-bottom: 16px;">
-        <div style="flex: 0 0 48%; border-radius: 12px; overflow: hidden;">
-          <img src="images/level-2/35-golden-sticky-1.jpg" alt="Golden Sticky Rose — Phase 1: Chakra Placement" style="width: 100%; height: auto; display: block; border-radius: 12px;">
+      <!-- 2x2 Grid of all 4 phases -->
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px; flex: 1;">
+
+        <!-- Phase 1 -->
+        <div style="display: flex; flex-direction: column;">
+          <div style="border-radius: 10px; overflow: hidden; margin-bottom: 4px;">
+            <img src="images/level-2/35-golden-sticky-1.jpg" alt="Golden Sticky Rose — Phase 1: Chakra Placement" style="width: 100%; height: auto; display: block; border-radius: 10px;">
+          </div>
+          <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 2px; color: var(--gold);">Phase 1 — Chakra Placement</p>
+          <p class="body" style="font-size: 7.5pt; line-height: 1.4;">Golden sticky roses are placed on each of the seven chakras, drawing out foreign energy lodged in the energy centers. Each rose adheres to the chakra and begins to absorb and extract energies that do not belong to you.</p>
         </div>
-        <div style="flex: 1;">
-          <p class="h-sm" style="font-size: 10pt; margin-bottom: 4px; color: var(--gold);">Phase 1 — Chakra Placement</p>
-          <p class="body" style="font-size: 9pt; line-height: 1.5;">Golden sticky roses are placed on each of the seven chakras, drawing out foreign energy lodged in the energy centers. Each rose adheres to the chakra and begins to absorb and extract energies that do not belong to you — clearing the way for deeper purification.</p>
+
+        <!-- Phase 2 -->
+        <div style="display: flex; flex-direction: column;">
+          <div style="border-radius: 10px; overflow: hidden; margin-bottom: 4px;">
+            <img src="images/level-2/36-golden-sticky-2.jpg" alt="Golden Sticky Rose — Phase 2: Body Placement" style="width: 100%; height: auto; display: block; border-radius: 10px;">
+          </div>
+          <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 2px; color: var(--gold);">Phase 2 — Body Placement</p>
+          <p class="body" style="font-size: 7.5pt; line-height: 1.4;">Golden sticky roses are placed at the joints and extremities — shoulders, elbows, wrists, hands, hips, knees, ankles, feet — drawing out foreign energy stored in the physical body.</p>
         </div>
+
+        <!-- Phase 3 -->
+        <div style="display: flex; flex-direction: column;">
+          <div style="border-radius: 10px; overflow: hidden; margin-bottom: 4px;">
+            <img src="images/level-2/37-golden-sticky-3.jpg" alt="Golden Sticky Rose — Phase 3: Full Body Coverage" style="width: 100%; height: auto; display: block; border-radius: 10px;">
+          </div>
+          <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 2px; color: var(--gold);">Phase 3 — Full Body Coverage</p>
+          <p class="body" style="font-size: 7.5pt; line-height: 1.4;">Golden sticky roses are placed throughout the entire body — covering the torso, limbs, and all remaining areas — for a thorough, complete energetic cleansing of the physical and energetic form.</p>
+        </div>
+
+        <!-- Phase 4 -->
+        <div style="display: flex; flex-direction: column;">
+          <div style="border-radius: 10px; overflow: hidden; margin-bottom: 4px;">
+            <img src="images/level-2/38-golden-sticky-4.jpg" alt="Golden Sticky Rose — Phase 4: Integration" style="width: 100%; height: auto; display: block; border-radius: 10px;">
+          </div>
+          <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 2px; color: var(--gold);">Phase 4 — Integration</p>
+          <p class="body" style="font-size: 7.5pt; line-height: 1.4;">A large Golden Rose appears above the head. All foreign energy gathered by the sticky roses is released upward, and the entire body is bathed in golden light — restoring, sealing, and integrating the energy body.</p>
+        </div>
+
       </div>
 
-      <!-- Phase 2 -->
-      <div style="display: flex; gap: 16px; align-items: flex-start;">
-        <div style="flex: 0 0 48%; border-radius: 12px; overflow: hidden;">
-          <img src="images/level-2/36-golden-sticky-2.jpg" alt="Golden Sticky Rose — Phase 2: Body Placement" style="width: 100%; height: auto; display: block; border-radius: 12px;">
-        </div>
-        <div style="flex: 1;">
-          <p class="h-sm" style="font-size: 10pt; margin-bottom: 4px; color: var(--gold);">Phase 2 — Body Placement</p>
-          <p class="body" style="font-size: 9pt; line-height: 1.5;">Golden sticky roses are placed at the joints and extremities of the body — shoulders, elbows, wrists, hands, hips, knees, ankles, feet — drawing out foreign energy stored in the physical body. These areas often hold tension and accumulated energies from daily interactions.</p>
-        </div>
+      <div style="height: 6px;"></div>
+      <div class="call-gold call">
+        <p style="color: var(--rose-800); font-size: 8pt;">The four phases work progressively — from the energy centers, to the joints, to the full body, and finally integration — ensuring a complete and thorough deep cleansing.</p>
       </div>
     </div>
 
@@ -1189,51 +1213,7 @@
   </div>
 
   <!-- =====================================================
-       PAGE 14 — GOLDEN STICKY ROSES Phase 3 & 4 (slides 37-38)
-       ===================================================== -->
-  <div class="page">
-    <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
-    <div class="ck ck-bl"></div><div class="ck ck-br"></div>
-
-    <div class="inner">
-      <div class="label">Deep Cleansing</div>
-      <div class="s8"></div>
-      <h2 class="h-lg">Golden Sticky Roses <span style="font-weight: 300; font-size: 0.7em;">(continued)</span></h2>
-      <div class="s8"></div>
-
-      <!-- Phase 3 -->
-      <div style="display: flex; gap: 16px; align-items: flex-start; margin-bottom: 16px;">
-        <div style="flex: 0 0 48%; border-radius: 12px; overflow: hidden;">
-          <img src="images/level-2/37-golden-sticky-3.jpg" alt="Golden Sticky Rose — Phase 3: Full Body Coverage" style="width: 100%; height: auto; display: block; border-radius: 12px;">
-        </div>
-        <div style="flex: 1;">
-          <p class="h-sm" style="font-size: 10pt; margin-bottom: 4px; color: var(--gold);">Phase 3 — Full Body Coverage</p>
-          <p class="body" style="font-size: 9pt; line-height: 1.5;">Golden sticky roses are placed throughout the entire body — covering the torso, limbs, and all remaining areas — for a thorough, complete energetic cleansing. Every surface of the body is covered, ensuring no foreign energy remains hidden in any part of the physical or energetic form.</p>
-        </div>
-      </div>
-
-      <!-- Phase 4 -->
-      <div style="display: flex; gap: 16px; align-items: flex-start;">
-        <div style="flex: 0 0 48%; border-radius: 12px; overflow: hidden;">
-          <img src="images/level-2/38-golden-sticky-4.jpg" alt="Golden Sticky Rose — Phase 4: Integration" style="width: 100%; height: auto; display: block; border-radius: 12px;">
-        </div>
-        <div style="flex: 1;">
-          <p class="h-sm" style="font-size: 10pt; margin-bottom: 4px; color: var(--gold);">Phase 4 — Integration</p>
-          <p class="body" style="font-size: 9pt; line-height: 1.5;">After the golden sticky roses have done their work, a large Golden Rose appears above the head. All foreign energy gathered by the sticky roses is released upward, and the entire body is bathed in golden light — restoring, sealing, and integrating the energy body. This completes the deep cleansing cycle, leaving you purified and whole.</p>
-        </div>
-      </div>
-
-      <div class="s20"></div>
-      <div class="call-gold call">
-        <p style="color: var(--rose-800);">The four phases of Golden Sticky Roses work progressively — from the energy centers, to the joints, to the full body, and finally integration — ensuring a complete and thorough deep cleansing.</p>
-      </div>
-    </div>
-
-    <div class="pn"><span>14</span></div>
-  </div>
-
-  <!-- =====================================================
-       PAGE 15 — ELEMENTS SUMMARY (Level 2)
+       PAGE 14 — ELEMENTS SUMMARY (Level 2)
        ===================================================== -->
   <div class="page">
     <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
@@ -1291,11 +1271,11 @@
       </div>
     </div>
 
-    <div class="pn"><span>15</span></div>
+    <div class="pn"><span>14</span></div>
   </div>
 
   <!-- =====================================================
-       PAGE 16 — CLOSING
+       PAGE 15 — CLOSING
        ===================================================== -->
   <div class="page closing-bg">
     <div class="ck ck-tl"></div><div class="ck ck-tr"></div>


### PR DESCRIPTION
## Summary
Reorganized the Golden Sticky Roses section from a two-page spread (Pages 13-14) into a single page with a 2x2 grid layout displaying all four phases simultaneously. This improves content density and visual organization while maintaining all instructional information.

## Key Changes
- **Layout restructuring**: Changed from sequential flex layout (Phase 1 & 2 on page 13, Phase 3 & 4 on page 14) to a 2x2 CSS grid layout on a single page
- **Page consolidation**: Merged two separate pages into one, reducing total page count by 1
- **Typography adjustments**: 
  - Reduced font sizes (body text from 9pt to 7.5pt, headings from 10pt to 8.5pt)
  - Adjusted line heights and spacing to accommodate compact grid layout
  - Modified spacing values (margins and gaps) for tighter visual hierarchy
- **Content refinement**: Slightly condensed descriptive text for each phase while preserving key information
- **Page numbering**: Updated all subsequent page numbers (Pages 15-16 become 14-15)
- **Image styling**: Adjusted border-radius from 12px to 10px for consistency with grid cells

## Implementation Details
- Used CSS Grid (`grid-template-columns: 1fr 1fr; gap: 10px`) to create responsive 2x2 phase layout
- Each phase cell uses flexbox with `flex-direction: column` for vertical stacking of image and text
- Maintained visual hierarchy with gold-colored phase titles and consistent spacing
- Preserved all four phase images and their alt text for accessibility
- Updated section header comment to reflect "All 4 Phases (slides 35-38)" instead of separate phase groupings

https://claude.ai/code/session_01RSeQFz8qCHfHKegyjfA7YF