### PR TITLE
Add Escola da Aura to spiritual lineage chain

### DIFF
--- a/scripts/generate-translated-teachers-aid.ts
+++ b/scripts/generate-translated-teachers-aid.ts
@@ -183,7 +183,7 @@ function translateHtml(html: string, t: Translation, locale: string): string {
     escapeHtml(t.opening.history.text)
   );
   result = result.replace(
-    'Lineage: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; ROSES OS',
+    'Lineage: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; Escola da Aura &rarr; ROSES OS',
     `${escapeHtml(t.ui.lineage)}: ${escapeHtml(t.opening.history.lineage).replace(/→/g, '&rarr;')}`
   );
 

--- a/scripts/pdf-manuals/roses-teachers-aid-el.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-el.html
@@ -531,7 +531,7 @@
       <div class="s8"></div>
       <p class="body">Η Ανάγνωση Αύρας εμφανίστηκε τη δεκαετία του 1960, στην Καλιφόρνια, διοχετευμένη από έναν Βορειοαμερικανό ονόματι Lewis S. Bostwick. Ιδρυτής του Berkeley Psychic Institute και της Church of the Divine Man, διοχέτευσε και συστηματοποίησε τις τεχνικές και τα εργαλεία που στάλθηκαν από τους αγγέλους, για να βοηθήσουν στη διαδικασία εξέλιξης της ανθρωπότητας.</p>
       <div class="s10"></div>
-      <p class="body-sm" style="font-style: italic; color: var(--rose-clay);">Καταγωγή: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; ROSES OS</p>
+      <p class="body-sm" style="font-style: italic; color: var(--rose-clay);">Καταγωγή: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; Escola da Aura &rarr; ROSES OS</p>
       <div class="s16"></div>
       <div style="text-align: center;">
         <img src="images/rose-emblem.png" alt="ROSES OS Emblem" style="width: 120px; height: auto; border-radius: 8px;">

--- a/scripts/pdf-manuals/roses-teachers-aid-es.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-es.html
@@ -531,7 +531,7 @@
       <div class="s8"></div>
       <p class="body">La Lectura del Aura surgió en la década de 1960, en California, canalizada por un norteamericano llamado Lewis S. Bostwick. Fundador del Berkeley Psychic Institute y de la Church of the Divine Man, canalizó y sistematizó las técnicas y herramientas enviadas por los ángeles, para asistir en el proceso de evolución de la humanidad.</p>
       <div class="s10"></div>
-      <p class="body-sm" style="font-style: italic; color: var(--rose-clay);">Linaje: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; ROSES OS</p>
+      <p class="body-sm" style="font-style: italic; color: var(--rose-clay);">Linaje: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; Escola da Aura &rarr; ROSES OS</p>
 
       <div class="s16"></div>
       <div style="text-align: center;">

--- a/scripts/pdf-manuals/roses-teachers-aid-pt.html
+++ b/scripts/pdf-manuals/roses-teachers-aid-pt.html
@@ -531,7 +531,7 @@
       <div class="s8"></div>
       <p class="body">A Leitura de Aura surgiu na década de 1960, na Califórnia, canalizada por um norte-americano chamado Lewis S. Bostwick. Fundador do Berkeley Psychic Institute e da Church of the Divine Man, ele canalizou e sistematizou as técnicas e ferramentas enviadas pelos anjos, para auxiliar no processo de evolução da humanidade.</p>
       <div class="s10"></div>
-      <p class="body-sm" style="font-style: italic; color: var(--rose-clay);">Linhagem: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; ROSES OS</p>
+      <p class="body-sm" style="font-style: italic; color: var(--rose-clay);">Linhagem: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; Escola da Aura &rarr; ROSES OS</p>
       <div class="s16"></div>
       <div style="text-align: center;">
         <img src="images/rose-emblem.png" alt="ROSES OS Emblem" style="width: 120px; height: auto; border-radius: 8px;">

--- a/scripts/pdf-manuals/roses-teachers-aid.html
+++ b/scripts/pdf-manuals/roses-teachers-aid.html
@@ -531,7 +531,7 @@
       <div class="s8"></div>
       <p class="body">Aura Reading emerged in the 1960s, in California, channeled by Lewis S. Bostwick. Founder of the Berkeley Psychic Institute and the Church of the Divine Man, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.</p>
       <div class="s10"></div>
-      <p class="body-sm" style="font-style: italic; color: var(--rose-clay);">Lineage: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; ROSES OS</p>
+      <p class="body-sm" style="font-style: italic; color: var(--rose-clay);">Lineage: Berkeley Psychic Institute &rarr; Anastasia Plunk &rarr; Angelina Ataide &rarr; Escola da Aura &rarr; ROSES OS</p>
 
       <div class="s16"></div>
       <div style="text-align: center;">

--- a/src/content/teaching/el.json
+++ b/src/content/teaching/el.json
@@ -57,7 +57,7 @@
     "history": {
       "title": "Ιστορία και Καταγωγή",
       "text": "Η Ανάγνωση Αύρας εμφανίστηκε τη δεκαετία του 1960, στην Καλιφόρνια, διοχετευμένη από έναν Βορειοαμερικανό ονόματι Lewis S. Bostwick. Ιδρυτής του Berkeley Psychic Institute και της Church of the Divine Man, διοχέτευσε και συστηματοποίησε τις τεχνικές και τα εργαλεία που στάλθηκαν από τους αγγέλους, για να βοηθήσουν στη διαδικασία εξέλιξης της ανθρωπότητας.",
-      "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → ROSES OS"
+      "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → Escola da Aura → ROSES OS"
     }
   },
   "levels": {

--- a/src/content/teaching/en.json
+++ b/src/content/teaching/en.json
@@ -57,7 +57,7 @@
     "history": {
       "title": "History & Lineage",
       "text": "Aura Reading emerged in the 1960s, in California, channeled by a North American called Lewis S. Bostwick. Founder of the Berkeley Psychic Institute and the Church of the Divine Man, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.",
-      "lineage": "Berkeley Psychic Institute \u2192 Anastasia Plunk \u2192 Angelina Ataide \u2192 ROSES OS"
+      "lineage": "Berkeley Psychic Institute \u2192 Anastasia Plunk \u2192 Angelina Ataide \u2192 Escola da Aura \u2192 ROSES OS"
     }
   },
   "levels": {

--- a/src/content/teaching/es.json
+++ b/src/content/teaching/es.json
@@ -57,7 +57,7 @@
     "history": {
       "title": "Historia y Linaje",
       "text": "La Lectura del Aura surgió en la década de 1960, en California, canalizada por un norteamericano llamado Lewis S. Bostwick. Fundador del Berkeley Psychic Institute y de la Church of the Divine Man, canalizó y sistematizó las técnicas y herramientas enviadas por los ángeles, para asistir en el proceso de evolución de la humanidad.",
-      "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → ROSES OS"
+      "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → Escola da Aura → ROSES OS"
     }
   },
   "levels": {

--- a/src/content/teaching/pt.json
+++ b/src/content/teaching/pt.json
@@ -57,7 +57,7 @@
     "history": {
       "title": "História e Linhagem",
       "text": "A Leitura de Aura surgiu na década de 1960, na Califórnia, canalizada por um norte-americano chamado Lewis S. Bostwick. Fundador do Berkeley Psychic Institute e da Church of the Divine Man, ele canalizou e sistematizou as técnicas e ferramentas enviadas pelos anjos, para auxiliar no processo de evolução da humanidade.",
-      "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → ROSES OS"
+      "lineage": "Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → Escola da Aura → ROSES OS"
     }
   },
   "levels": {

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -449,7 +449,8 @@ export const lineageEntries: LineageEntry[] = [
   { id: '1', year: '1960s', name: 'Lewis S. Bostwick', description: 'Channeled the material of Aura Reading in California. Founder of the Berkeley Psychic Institute and the Church of the Divine Man.' },
   { id: '2', year: '1980s', name: 'Anastasia Plunk', description: 'Received and carried the Aura Reading and Rose meditation teachings from the Berkeley Psychic Institute, ensuring the continuity and integrity of the lineage.' },
   { id: '3', year: '2000s', name: 'Angelina Ataide', description: 'Founder of CELARIS (Center of Aura Readings, Reiki, Intuition and Dreams).' },
-  { id: '4', year: '2026', name: 'ROSES OS', description: 'The platform crystallizes decades of lineage wisdom into an accessible ecosystem for consciousness, remembrance, and coherent living.' },
+  { id: '4', year: '2020s', name: 'Escola da Aura', description: 'The school founded to transmit and preserve the teachings of Aura Reading, bridging the lineage into a structured educational path.' },
+  { id: '5', year: '2026', name: 'ROSES OS', description: 'The platform crystallizes decades of lineage wisdom into an accessible ecosystem for consciousness, remembrance, and coherent living.' },
 ];
 
 // =============================================================================

--- a/src/lib/data/teaching-slides.ts
+++ b/src/lib/data/teaching-slides.ts
@@ -36,7 +36,7 @@ export const openingImportantToKnow = {
 export const openingHistory = {
   title: 'History & Lineage',
   text: 'Aura Reading emerged in the 1960s, in California, channeled by a North American called Lewis S. Bostwick. Founder of the Berkeley Psychic Institute and the Church of the Divine Man, he channeled and systematized the techniques and tools sent by the angels, to assist in the process of evolution of humanity.',
-  lineage: 'Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → ROSES OS',
+  lineage: 'Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → Escola da Aura → ROSES OS',
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary
This PR adds "Escola da Aura" as a new entry in the Aura Reading spiritual lineage, positioning it between Angelina Ataide and ROSES OS. This represents the formalization of the educational institution that bridges the traditional lineage teachings into a structured learning path.

## Key Changes
- Added new lineage entry for "Escola da Aura" (2020s) in mock data with description of its role in transmitting and preserving Aura Reading teachings
- Updated lineage chain across all content files and translations (English, Spanish, Portuguese, Greek) to include: Berkeley Psychic Institute → Anastasia Plunk → Angelina Ataide → **Escola da Aura** → ROSES OS
- Renumbered ROSES OS entry from id '4' to '5' to accommodate the new lineage entry
- Updated lineage references in:
  - Teaching content JSON files (en, es, pt, el)
  - PDF manual templates (all language versions)
  - Teaching slides data
  - Translation generation script

## Implementation Details
The change maintains consistency across all language versions and documentation formats, ensuring the updated lineage is reflected uniformly throughout the application and generated materials.

https://claude.ai/code/session_01W3vzvs9wRZeyCP9863sk5k