### PR TITLE
Split Golden Sticky Roses content across two pages

### DIFF
--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -1149,7 +1149,7 @@
   </div>
 
   <!-- =====================================================
-       PAGE 13 — GOLDEN STICKY ROSES All 4 Phases (slides 35-38)
+       PAGE 13 — GOLDEN STICKY ROSES Phases 1 & 2 (slides 35-36)
        ===================================================== -->
   <div class="page">
     <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
@@ -1162,8 +1162,8 @@
       <div style="height: 4px;"></div>
       <p class="body" style="margin-bottom: 6px; font-size: 8.5pt;">Golden sticky roses are used for deep energetic cleansing of the body, placed in four progressive phases:</p>
 
-      <!-- 2x2 Grid of all 4 phases -->
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px; flex: 1;">
+      <!-- Side-by-side: Phases 1 & 2 -->
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px;">
 
         <!-- Phase 1 -->
         <div style="display: flex; flex-direction: column;">
@@ -1182,6 +1182,28 @@
           <p class="h-sm" style="font-size: 8.5pt; margin-bottom: 2px; color: var(--gold);">Phase 2 — Body Placement</p>
           <p class="body" style="font-size: 7.5pt; line-height: 1.4;">Golden sticky roses are placed at the joints and extremities — shoulders, elbows, wrists, hands, hips, knees, ankles, feet — drawing out foreign energy stored in the physical body.</p>
         </div>
+
+      </div>
+    </div>
+
+    <div class="pn"><span>13</span></div>
+  </div>
+
+  <!-- =====================================================
+       PAGE 14 — GOLDEN STICKY ROSES Phases 3 & 4 (slides 37-38)
+       ===================================================== -->
+  <div class="page">
+    <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
+    <div class="ck ck-bl"></div><div class="ck ck-br"></div>
+
+    <div class="inner">
+      <div class="label">Deep Cleansing</div>
+      <div class="s8"></div>
+      <h2 class="h-lg">Golden Sticky Roses <span style="font-weight: 400; font-size: 0.75em;">(continued)</span></h2>
+      <div style="height: 4px;"></div>
+
+      <!-- Side-by-side: Phases 3 & 4 -->
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px;">
 
         <!-- Phase 3 -->
         <div style="display: flex; flex-direction: column;">
@@ -1209,11 +1231,11 @@
       </div>
     </div>
 
-    <div class="pn"><span>13</span></div>
+    <div class="pn"><span>14</span></div>
   </div>
 
   <!-- =====================================================
-       PAGE 14 — ELEMENTS SUMMARY (Level 2)
+       PAGE 15 — ELEMENTS SUMMARY (Level 2)
        ===================================================== -->
   <div class="page">
     <div class="ck ck-tl"></div><div class="ck ck-tr"></div>
@@ -1271,7 +1293,7 @@
       </div>
     </div>
 
-    <div class="pn"><span>14</span></div>
+    <div class="pn"><span>15</span></div>
   </div>
 
   <!-- =====================================================


### PR DESCRIPTION
## Summary
Reorganized the Golden Sticky Roses section in the PDF manual to split the four phases across two dedicated pages for improved readability and layout.

## Key Changes
- **Page 13 (Golden Sticky Roses)**: Now displays only Phases 1 & 2 with updated comment and removed `flex: 1` style from grid container
- **Page 14 (new)**: Created new page dedicated to Phases 3 & 4 with "(continued)" subtitle
- **Page numbering**: Updated all subsequent page numbers (former Page 14 → Page 15) to accommodate the new page
- **Content organization**: Each phase pair now has dedicated space with consistent layout and styling

## Implementation Details
- Removed the 2x2 grid layout that displayed all 4 phases on a single page
- Maintained consistent grid structure (2 columns, 10px gap) for both new pages
- Added proper page break structure with corner decorations and page numbers
- Preserved all phase descriptions and styling while improving visual hierarchy

https://claude.ai/code/session_014YV3vDbd3EX3UnHL6SHsZk