### PR TITLE
Replace rose SVG icon with image in manual TOC

### DIFF
--- a/scripts/pdf-manuals/roses-manual-1.html
+++ b/scripts/pdf-manuals/roses-manual-1.html
@@ -378,17 +378,9 @@
       <div class="line"></div>
       <div class="s12"></div>
 
-      <!-- Rose icon on TOC -->
-      <div style="text-align: center; margin-bottom: 8px;">
-        <svg style="width: 28px; height: 28px;" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="50" cy="50" r="18" fill="none" stroke="#9C6F6E" stroke-width="1.5"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(0 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(72 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(144 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(216 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(288 50 50)"/>
-          <circle cx="50" cy="50" r="5" fill="#9C6F6E" opacity="0.3"/>
-        </svg>
+      <!-- Rose image on TOC -->
+      <div class="img-center" style="margin-bottom: 8px;">
+        <img src="images/level-1/01-the-rose.PNG" alt="The Rose" style="width: 120px; border-radius: 12px; outline: 0.5px solid var(--rose-200);">
       </div>
 
       <table style="width: 100%; border-collapse: collapse;">
@@ -475,7 +467,7 @@
       <div class="s16"></div>
 
       <div class="img-full" style="max-width: 280px;">
-        <img src="images/level-1/01-the-rose.PNG" alt="The Rose" style="border-radius: 16px;">
+        <img src="images/level-1/02-meditation-posture.PNG" alt="Meditation Posture" style="border-radius: 16px;">
       </div>
       <div class="s16"></div>
 


### PR DESCRIPTION
## Summary
Updated the Rose Meditation section in the manual to replace an inline SVG rose icon with an actual image file, and corrected a mismatched image reference in the "Getting Ready to Start" section.

## Key Changes
- Replaced the hand-coded SVG rose icon in the table of contents with an image element (`01-the-rose.PNG`)
- Updated the TOC container from inline styles to use the `img-center` class for consistent styling
- Fixed incorrect image reference in the "Getting Ready to Start" section, changing from `01-the-rose.PNG` to the correct `02-meditation-posture.PNG`
- Applied consistent styling to the new TOC image with border-radius and outline properties

## Implementation Details
- The SVG icon (which used circles and rotated ellipses to create a rose design) has been replaced with a 120px wide image
- The image includes a subtle outline using the `--rose-200` CSS variable for visual consistency
- The "Getting Ready to Start" section now displays the appropriate meditation posture image instead of duplicating the rose image

https://claude.ai/code/session_01Wm84mYX7HsT9jQ55pgZCWb