### PR TITLE
Adjust image max-width in Energy Recovery section

### DIFF
--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -1135,7 +1135,7 @@
       <p class="body">After cleansing, the energy recovery process is repeated at a deeper level. The Rose is sent out to gather and return your own energy to each individual chakra, restoring sovereignty, vitality, and wholeness to each energy center.</p>
       <div class="s20"></div>
 
-      <div class="img-full" style="max-width: 420px;">
+      <div class="img-full" style="max-width: 320px;">
         <img src="images/level-2/34-energy-recovery.png" alt="Energy Recovery">
       </div>
       <div class="s24"></div>


### PR DESCRIPTION
## Summary
Updated the maximum width constraint for the Energy Recovery image in the Roses Manual to improve layout and visual presentation.

## Changes
- Reduced the `max-width` style property of the Energy Recovery image from `420px` to `320px` in the "Energy Recovery of Each Chakra" section

## Details
This adjustment ensures the image displays at a more appropriate size within the manual's layout, likely to better fit the page width or improve visual hierarchy within the document.

https://claude.ai/code/session_016HzxgQdFMgYZjGCKiwqK6b