### PR TITLE
Replace inline SVG rose icons with image assets

### DIFF
--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -290,14 +290,6 @@
       border-radius: 20px;
     }
 
-    /* Rose icon (inline SVG for TOC decoration) */
-    .rose-icon {
-      display: inline-block;
-      width: 28px;
-      height: 28px;
-      margin: 0 auto 8px auto;
-    }
-
     /* ============================================================
        CHAKRA CARDS
        ============================================================ */
@@ -459,16 +451,8 @@
       <div class="s16"></div>
 
       <!-- Rose icon on TOC -->
-      <div style="text-align: center; margin-bottom: 12px;">
-        <svg class="rose-icon" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="50" cy="50" r="18" fill="none" stroke="#9C6F6E" stroke-width="1.5"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(0 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(72 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(144 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(216 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(288 50 50)"/>
-          <circle cx="50" cy="50" r="5" fill="#9C6F6E" opacity="0.3"/>
-        </svg>
+      <div class="img-circle" style="width: 36px; height: 36px; margin: 0 auto 8px auto;">
+        <img src="images/level-1/01-the-rose.PNG" alt="The Rose" style="object-position: top;">
       </div>
 
       <table style="width: 100%; border-collapse: collapse;">

--- a/scripts/pdf-manuals/roses-manual-3.html
+++ b/scripts/pdf-manuals/roses-manual-3.html
@@ -270,16 +270,8 @@
       <div class="s12"></div>
 
       <!-- Rose icon on TOC -->
-      <div style="text-align: center; margin-bottom: 8px;">
-        <svg style="width: 28px; height: 28px;" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="50" cy="50" r="18" fill="none" stroke="#9C6F6E" stroke-width="1.5"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(0 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(72 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(144 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(216 50 50)"/>
-          <ellipse cx="50" cy="32" rx="8" ry="14" fill="none" stroke="#D4A09A" stroke-width="1" transform="rotate(288 50 50)"/>
-          <circle cx="50" cy="50" r="5" fill="#9C6F6E" opacity="0.3"/>
-        </svg>
+      <div class="img-circle" style="width: 36px; height: 36px; margin: 0 auto 8px auto;">
+        <img src="images/level-1/01-the-rose.PNG" alt="The Rose" style="object-position: top;">
       </div>
 
       <table style="width: 100%; border-collapse: collapse;">


### PR DESCRIPTION
## Summary
Replaced inline SVG rose icon decorations with image assets across PDF manual files. This simplifies the markup and improves maintainability by using a single image file instead of duplicated SVG code.

## Key Changes
- Removed `.rose-icon` CSS class definition from roses-manual-2.html (8 lines)
- Replaced inline SVG rose icons in roses-manual-2.html with `<img>` tag referencing `images/level-1/01-the-rose.PNG`
- Replaced inline SVG rose icons in roses-manual-3.html with `<img>` tag referencing `images/level-1/01-the-rose.PNG`
- Updated container styling to use existing `.img-circle` class with consistent dimensions (36px × 36px)
- Added `object-position: top;` to image styling for proper alignment

## Implementation Details
- The SVG markup (12 lines per instance) was replaced with a single `<img>` element
- Both files now reference the same rose image asset, reducing code duplication
- Container styling leverages the existing `.img-circle` utility class for consistency
- Image dimensions increased from 28px to 36px for better visibility
- Alt text "The Rose" added for accessibility

https://claude.ai/code/session_01CThcz8grC4LkivrzRVnNt1