### PR TITLE
Add nadi-full styling for chakra images in manual

### DIFF
--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -314,6 +314,10 @@
       display: block;
       border-radius: 12px;
     }
+    .chakra-img img.nadi-full {
+      height: 180px;
+      object-position: center bottom;
+    }
 
     .chakra-info {
       flex: 1;
@@ -691,7 +695,7 @@
       <!-- Root Chakra -->
       <div class="chakra-card">
         <div class="chakra-img">
-          <img src="images/level-2/25-root-chakra.jpeg" alt="Root Chakra">
+          <img class="nadi-full" src="images/level-2/25-root-chakra.jpeg" alt="Root Chakra">
         </div>
         <div class="chakra-info">
           <div class="chakra-name" style="color: #DC2626;">Root Chakra</div>
@@ -733,7 +737,7 @@
       <!-- Sacral Chakra -->
       <div class="chakra-card">
         <div class="chakra-img">
-          <img src="images/level-2/26-sacral-chakra.jpeg" alt="Sacral Chakra">
+          <img class="nadi-full" src="images/level-2/26-sacral-chakra.jpeg" alt="Sacral Chakra">
         </div>
         <div class="chakra-info">
           <div class="chakra-name" style="color: #EA580C;">Sacral Chakra</div>


### PR DESCRIPTION
## Summary
Added CSS styling to properly display full-height chakra images in the roses manual with centered bottom positioning, and applied the new style class to root and sacral chakra images.

## Key Changes
- Added `.chakra-img img.nadi-full` CSS class with:
  - `height: 180px` to set consistent image height
  - `object-position: center bottom` to align images from the bottom center
- Applied `nadi-full` class to root chakra image (25-root-chakra.jpeg)
- Applied `nadi-full` class to sacral chakra image (26-sacral-chakra.jpeg)

## Implementation Details
The new styling ensures chakra images display at a fixed height with proper positioning, likely to be applied to remaining chakra images in subsequent updates. The `object-position: center bottom` property ensures images are cropped/positioned from the bottom while maintaining center horizontal alignment.

https://claude.ai/code/session_01DdDReEg1rzEoUcDhY1A8Lj