### PR TITLE
Remove nadi-full image styling from roses manual

### DIFF
--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -314,10 +314,6 @@
       display: block;
       border-radius: 12px;
     }
-    .chakra-img img.nadi-full {
-      height: 180px;
-      object-position: center bottom;
-    }
 
     .chakra-info {
       flex: 1;


### PR DESCRIPTION
## Summary
Removed unused CSS styling rules for the `.chakra-img img.nadi-full` selector from the roses manual HTML document.

## Changes
- Deleted 4 lines of CSS that defined height and object-position properties for the nadi-full image class
- The removed styles set a fixed height of 180px and positioned the image to center-bottom

## Details
This appears to be a cleanup of unused or obsolete styling rules. The nadi-full image class styling is no longer needed in the manual, so the associated CSS has been removed to reduce stylesheet bloat and improve maintainability.

https://claude.ai/code/session_01XPcWgVJHvtqqH7vh8Kt8GB