### PR TITLE
Remove "Analyzer & Sacred Space" slide from Level 3 content

### DIFF
--- a/scripts/pdf-manuals/roses-manual-3.html
+++ b/scripts/pdf-manuals/roses-manual-3.html
@@ -347,13 +347,8 @@
       <h2 class="h-lg">The Analyzer</h2>
       <div class="s10"></div>
 
-      <div class="cols" style="align-items: flex-start;">
-        <div class="img-full" style="width: 100%; max-width: none; border-radius: 12px;">
-          <img src="images/level-3/39-analyzer.PNG" alt="The Analyzer" style="border-radius: 12px;">
-        </div>
-        <div class="img-full" style="width: 100%; max-width: none; border-radius: 12px;">
-          <img src="images/level-3/40-analyzer-and-sacred-space.png" alt="Sacred Space & Analyzer" style="border-radius: 12px;">
-        </div>
+      <div class="img-full" style="width: 100%; max-width: none; border-radius: 12px;">
+        <img src="images/level-3/39-analyzer.PNG" alt="The Analyzer" style="border-radius: 12px;">
       </div>
       <div class="s10"></div>
 

--- a/scripts/pdf-manuals/roses-teachers-aid.html
+++ b/scripts/pdf-manuals/roses-teachers-aid.html
@@ -1459,20 +1459,6 @@
       <div class="s10"></div>
       <p class="body">The Analyzer is an energetic point located at the back of the head, at the base of the skull. It is used for deeper perception, reading, and discernment of energy.</p>
 
-      <div class="s16"></div>
-      <div class="line"></div>
-      <div class="s16"></div>
-
-      <div class="step">
-        <div class="sn">40</div>
-        <h3 class="h-md">The Analyzer &amp; Sacred Space</h3>
-      </div>
-      <div class="s10"></div>
-      <div class="img-center">
-        <img src="images/level-3/40-analyzer-and-sacred-space.png" alt="Analyzer and Sacred Space" style="width: 280px; border-radius: 16px; outline: 0.5px solid var(--rose-200);">
-      </div>
-      <div class="s10"></div>
-      <p class="body">A combined reference showing the Analyzer in relation to the sacred space. The sacred space provides the container, the Analyzer provides the perceptive tool.</p>
     </div>
 
     <div class="pn"><span>24</span></div>

--- a/src/lib/data/manual-image-mapping.ts
+++ b/src/lib/data/manual-image-mapping.ts
@@ -120,7 +120,6 @@ export const level3ManualImages: ManualImageMapping = {
       title: 'The Analyzer',
       images: [
         { concept: 'The Analyzer', slideNumber: 39, reimaginedImage: 'level-3/39-analyzer.PNG' },
-        { concept: 'Analyzer + Sacred Space', slideNumber: 40, reimaginedImage: 'level-3/40-analyzer-and-sacred-space.png' },
       ],
     },
     {

--- a/src/lib/data/teaching-slides.ts
+++ b/src/lib/data/teaching-slides.ts
@@ -672,16 +672,6 @@ export const level3Slides: TeachingSlide[] = [
     section: 'advanced',
   },
   {
-    id: 'l3-analyzer-sacred-space',
-    slideNumber: 40,
-    concept: 'The Analyzer & Sacred Space',
-    teachingText:
-      'A combined reference showing the Analyzer in relation to the sacred space. This image illustrates how the Analyzer — the energetic point at the base of the skull — operates within the context of the protected, cleansed sacred space established in Level 2. The two work together: the sacred space provides the container, and the Analyzer provides the perceptive tool for deeper energetic reading and discernment.',
-    reimaginedImage: 'level-3/40-analyzer-and-sacred-space.png',
-    level: 3,
-    section: 'advanced',
-  },
-  {
     id: 'l3-stick-of-agreements',
     slideNumber: 41,
     concept: 'Stick of Agreements',


### PR DESCRIPTION
## Summary
This PR removes the "Analyzer & Sacred Space" teaching slide (slide 40) from the Level 3 curriculum across all related files. This appears to be a content consolidation effort, removing a combined reference slide while keeping the standalone "Analyzer" slide.

## Key Changes
- **roses-teachers-aid.html**: Removed the entire slide 40 section including the step header, image reference, and descriptive text about the Analyzer in relation to sacred space
- **teaching-slides.ts**: Removed the `l3-analyzer-sacred-space` slide entry from the Level 3 slides array
- **roses-manual-3.html**: Simplified the Analyzer section by removing the two-column layout that displayed both the Analyzer and Analyzer & Sacred Space images, keeping only the standalone Analyzer image
- **manual-image-mapping.ts**: Removed the "Analyzer + Sacred Space" image mapping entry from the Level 3 manual images

## Implementation Details
The removal is consistent across all content sources, ensuring no orphaned references remain. The standalone "Analyzer" slide (slide 39) is preserved, maintaining the core teaching content while eliminating the combined reference slide.

https://claude.ai/code/session_01JobeKukDbF2LUBpBEzvpNE