### PR TITLE
Remove Diego Dosal from guardians list

### DIFF
--- a/src/app/(site)/guardians/page.tsx
+++ b/src/app/(site)/guardians/page.tsx
@@ -10,7 +10,7 @@ import {
 export const metadata: Metadata = {
   title: 'Guardians',
   description:
-    'Meet the guardians of ROSES OS — Angelina Ataíde, Dara Ayoub, Diego Dosal, and Peggy Mars. Teachers, stewards, and practitioners carrying the Rose Meditation and Aura Reading lineage.',
+    'Meet the guardians of ROSES OS — Angelina Ataíde, Dara Ayoub, and Peggy Mars. Teachers, stewards, and practitioners carrying the Rose Meditation and Aura Reading lineage.',
   keywords: [
     'rose meditation teachers',
     'aura reading teachers',

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -46,13 +46,6 @@ export const guardians: Guardian[] = [
     imageScale: 1.0,
   },
   {
-    id: '2',
-    name: 'Diego Dosal',
-    role: 'Guardian of Architecture & Structure',
-    bio: 'Diego is the bridge between spirit and structure. With over a decade of deep roots in multiple paths of spiritual practice, energy work, and community building, he carries the horizontal axis of ROSES OS by developing platforms, systems, and frameworks that harmonize intuition with strategy and build lasting foundations for this work.',
-    image: '/images/61C5142D-1CB2-414A-BAED-1C2E2E30217E.png',
-  },
-  {
     id: '4',
     name: 'Peggy Mars',
     role: 'Guardian of Methodology',


### PR DESCRIPTION
## Summary
This PR removes Diego Dosal from the guardians list and updates related metadata references.

## Key Changes
- Removed Diego Dosal's guardian profile entry from the mock data (id: '2')
- Updated the guardians page metadata description to remove Diego Dosal's name from the list of guardians

## Details
The changes affect:
1. **src/lib/data/mock-data.ts** - Removed the complete guardian object for Diego Dosal, including his name, role, bio, and image reference
2. **src/app/(site)/guardians/page.tsx** - Updated the page metadata description to reflect only three guardians (Angelina Ataíde, Dara Ayoub, and Peggy Mars) instead of four

This ensures consistency between the displayed guardians list and the page's SEO metadata.

https://claude.ai/code/session_01VT2JmUzA7Ub7A8XmC8neZx