### PR TITLE
Refine navigation layout and logo sizing for better responsive design

### DIFF
--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -16,7 +16,7 @@ interface LogoProps {
 const sizeMap = {
   sm: 'text-base',
   md: 'text-lg',
-  lg: 'text-sm sm:text-base md:text-lg lg:text-xl',
+  lg: 'text-sm sm:text-base md:text-lg lg:text-base xl:text-xl',
 };
 
 export function Logo({

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -209,7 +209,7 @@ export function Navigation({
         <nav className="container-premium">
           <div className="relative flex items-center h-16 lg:h-[72px] w-full">
             {/* Left: nav links — equal flex so logo stays centered */}
-            <div className="hidden lg:flex items-center gap-1 flex-1 min-w-0 justify-start lg:pr-20">
+            <div className="hidden lg:flex items-center gap-1 flex-1 min-w-0 justify-start lg:pr-28 xl:pr-20">
               {items.map((item) => {
                 const isActive = isNavActive(item.href);
                 return (
@@ -239,12 +239,12 @@ export function Navigation({
             </div>
 
             {/* Logo — left-aligned on mobile/tablet, absolutely centered on desktop */}
-            <div className="z-10 min-w-0 lg:flex-shrink-0 lg:absolute lg:left-1/2 lg:top-1/2 lg:-translate-x-1/2 lg:-translate-y-1/2">
+            <div className="z-10 flex-1 min-w-0 lg:flex-initial lg:flex-shrink-0 lg:absolute lg:left-1/2 lg:top-1/2 lg:-translate-x-1/2 lg:-translate-y-1/2">
               {logo || <Logo size="lg" />}
             </div>
 
             {/* Right: CTA + hamburger — equal flex to balance left */}
-            <div className="flex items-center gap-2 flex-1 min-w-0 justify-end">
+            <div className="flex items-center gap-2 shrink-0 lg:flex-1 lg:min-w-0 justify-end">
               {/* CTA — pill + circle, fill-sweep on hover */}
               <Link
                 href={cta.href}


### PR DESCRIPTION
## Summary
This PR adjusts the responsive behavior of the navigation component and logo sizing to improve layout consistency across different screen sizes, particularly at the lg/xl breakpoints.

## Key Changes
- **Navigation left section**: Added `xl:pr-20` to reduce padding on extra-large screens while maintaining `lg:pr-28` for large screens, preventing excessive spacing
- **Logo container**: Changed from `flex-1` on mobile to `lg:flex-initial` on desktop, allowing the logo to size naturally while maintaining centered positioning on larger screens
- **Navigation right section**: Updated to use `shrink-0` on mobile (preventing unwanted shrinking) and `lg:flex-1 lg:min-w-0` on desktop (restoring flex behavior for proper spacing balance)
- **Logo sizing**: Adjusted the `lg` size variant to use `lg:text-base xl:text-xl`, scaling the logo down at the lg breakpoint and back up at xl for better visual hierarchy

## Implementation Details
These changes maintain the three-column navigation layout (left links, centered logo, right CTA) while improving the responsive scaling behavior. The adjustments ensure proper spacing and sizing transitions between breakpoints, particularly addressing the gap between lg (1024px) and xl (1280px) screen sizes.

https://claude.ai/code/session_017QNFcgDnjD9aWE5vNdrzri