### PR TITLE
Remove image placeholder from Classes & Consultations section

### DIFF
--- a/scripts/generate-manual-pdfs.py
+++ b/scripts/generate-manual-pdfs.py
@@ -1035,13 +1035,6 @@ LEVEL_3_HTML = """<!DOCTYPE html>
 <div class="page-break"></div>
 <h2>Classes &amp; Consultations</h2>
 
-<div class="image-placeholder">
-  <div class="ph-icon">&#9702;</div>
-  <p class="ph-label">Illustration — Classes &amp; Consultations</p>
-  <p class="ph-desc">A teacher or practitioner seated across from a student or client, both within their own auras. The practitioner's aura is shown with roses of protection, separation and observation. Energetic cords connect the two auras, illustrating the bonds that form during a session and need to be cleansed afterward.</p>
-  <p class="ph-ref">Ref: Classes &amp; Consultations — Energy Separation</p>
-</div>
-
 <p>When you are working in any field — or when you are a teacher or lecturer — you can use Rose Meditation to maintain your energy integrity.</p>
 
 <h3>Before</h3>


### PR DESCRIPTION
## Summary
Removed an image placeholder div from the Classes & Consultations section in the manual PDF generation script.

## Changes
- Deleted the image placeholder HTML block that was displaying a circular icon and descriptive text about an illustration of a teacher-student energy interaction
- The placeholder included a reference label "Classes & Consultations — Energy Separation" and detailed description of the intended illustration content
- The actual content section ("When you are working in any field...") remains intact

## Details
This appears to be cleanup of a placeholder element, likely because:
- The actual illustration will be added separately, or
- The placeholder is no longer needed in the current version of the manual
- The descriptive text may have been moved or consolidated elsewhere

The removal does not affect the functional content of the Classes & Consultations section.

https://claude.ai/code/session_01Fk6esjV1HBsMcu34fTH12B