### PR TITLE
Add redirects for renamed manual PDFs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,26 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: true,
   },
   serverExternalPackages: ['sharp'],
+  async redirects() {
+    return [
+      // Manual PDFs were renamed from ROSES-OS-Level-* to Rose-Level-* (commit 2dddb20)
+      {
+        source: '/resources/manuals/ROSES-OS-Level-1-Manual-EN.pdf',
+        destination: '/resources/manuals/Rose-Level-1-Manual-EN.pdf',
+        permanent: true,
+      },
+      {
+        source: '/resources/manuals/ROSES-OS-Level-2-Manual-EN.pdf',
+        destination: '/resources/manuals/Rose-Level-2-Manual-EN.pdf',
+        permanent: true,
+      },
+      {
+        source: '/resources/manuals/ROSES-OS-Level-3-Manual-EN.pdf',
+        destination: '/resources/manuals/Rose-Level-3-Manual-EN.pdf',
+        permanent: true,
+      },
+    ];
+  },
   outputFileTracingExcludes: {
     // Exclude heavy public/ directories from serverless function bundles.
     // These are served as static assets by Vercel's CDN — they don't need


### PR DESCRIPTION
## Summary
Added permanent redirects in Next.js configuration to handle renamed manual PDF files, ensuring old URLs continue to work and maintain backward compatibility.

## Key Changes
- Configured `redirects()` function in `next.config.ts` to map old manual PDF URLs to their new locations
- Added three permanent redirects for renamed manual files:
  - `ROSES-OS-Level-1-Manual-EN.pdf` → `Rose-Level-1-Manual-EN.pdf`
  - `ROSES-OS-Level-2-Manual-EN.pdf` → `Rose-Level-2-Manual-EN.pdf`
  - `ROSES-OS-Level-3-Manual-EN.pdf` → `Rose-Level-3-Manual-EN.pdf`

## Implementation Details
- Used permanent (HTTP 308) redirects to preserve SEO value and indicate the change is permanent
- Redirects are configured at the Next.js framework level, ensuring they work across all deployment environments
- This maintains backward compatibility for users with bookmarked or shared links to the old manual URLs

https://claude.ai/code/session_01BzhRUWxdweMs8EXV3w2NNN