### PR TITLE
Simplify International Aura School label in PDF manuals

### DIFF
--- a/scripts/pdf-manuals/roses-manual-1.html
+++ b/scripts/pdf-manuals/roses-manual-1.html
@@ -327,7 +327,7 @@
     <div class="ck ck-bl"></div><div class="ck ck-br"></div>
 
     <div class="inner" style="align-items: center; justify-content: center; text-align: center;">
-      <div class="label">International Aura School &nbsp;·&nbsp; A Consciousness &amp; Remembrance Ecosystem</div>
+      <div class="label">International Aura School</div>
       <div class="s28"></div>
 
       <div class="img-circle" style="width: 320px; height: 320px;">

--- a/scripts/pdf-manuals/roses-manual-2.html
+++ b/scripts/pdf-manuals/roses-manual-2.html
@@ -400,7 +400,7 @@
     <div class="ck ck-bl"></div><div class="ck ck-br"></div>
 
     <div class="inner" style="align-items: center; justify-content: center; text-align: center;">
-      <div class="label">International Aura School &nbsp;·&nbsp; A Consciousness &amp; Remembrance Ecosystem</div>
+      <div class="label">International Aura School</div>
       <div class="s28"></div>
 
       <div class="img-circle" style="width: 320px; height: 320px;">

--- a/scripts/pdf-manuals/roses-manual-3.html
+++ b/scripts/pdf-manuals/roses-manual-3.html
@@ -219,7 +219,7 @@
     <div class="ck ck-bl"></div><div class="ck ck-br"></div>
 
     <div class="inner" style="align-items: center; justify-content: center; text-align: center;">
-      <div class="label">International Aura School &nbsp;·&nbsp; A Consciousness &amp; Remembrance Ecosystem</div>
+      <div class="label">International Aura School</div>
       <div class="s28"></div>
 
       <div class="img-circle" style="width: 320px; height: 320px;">


### PR DESCRIPTION
## Summary
Updated the header label text across all three PDF manual files to remove the tagline "A Consciousness & Remembrance Ecosystem" and display only "International Aura School".

## Changes
- Removed the descriptive tagline from the label element in roses-manual-1.html
- Removed the descriptive tagline from the label element in roses-manual-2.html
- Removed the descriptive tagline from the label element in roses-manual-3.html

## Details
The label text was simplified from:
```
International Aura School · A Consciousness & Remembrance Ecosystem
```

To:
```
International Aura School
```

This change applies consistently across all three manual documents, maintaining the same HTML structure and styling while only modifying the text content.

https://claude.ai/code/session_0142jLucEMPj3JTCeKjkawii