### PR TITLE
Update Rose Meditation level descriptions in manuals

### DIFF
--- a/scripts/pdf-manuals/roses-manual-1.html
+++ b/scripts/pdf-manuals/roses-manual-1.html
@@ -337,7 +337,7 @@
 
       <h1 class="h-xl">Rose Meditation</h1>
       <div class="s6"></div>
-      <p class="sub">Level 1 of 3</p>
+      <p class="sub">Level 1 — Initiation Course</p>
       <div class="s32"></div>
 
       <div class="line-c"></div>

--- a/scripts/pdf-manuals/roses-manual-3.html
+++ b/scripts/pdf-manuals/roses-manual-3.html
@@ -229,7 +229,7 @@
 
       <h1 class="h-xl">Rose Meditation</h1>
       <div class="s6"></div>
-      <p class="sub">Level 3 — Initiation Course</p>
+      <p class="sub">Level 3 of 3</p>
       <div class="s32"></div>
 
       <div class="line-c"></div>


### PR DESCRIPTION
## Summary
Updated the level descriptions for Rose Meditation in the manual HTML files to correct inconsistent labeling between Level 1 and Level 3.

## Changes
- **roses-manual-1.html**: Changed Level 1 subtitle from "Level 1 of 3" to "Level 1 — Initiation Course" for consistency with course naming conventions
- **roses-manual-3.html**: Changed Level 3 subtitle from "Level 3 — Initiation Course" to "Level 3 of 3" to properly indicate the final level in the progression

## Details
These changes standardize the level descriptions across the manual documents, ensuring that the progression numbering and course designation are clearly and consistently presented to users.

https://claude.ai/code/session_01Xikk6brQ1Kt6s9FhfeXrVT