### PR TITLE
Fix TypeScript errors causing CI deploy failure

### DIFF
--- a/scripts/generate-images-v4.ts
+++ b/scripts/generate-images-v4.ts
@@ -220,11 +220,11 @@ async function generatePrompts(ai: GoogleGenAI): Promise<GeneratedPrompt[]> {
       }
     });
     
-    const text = response.text;
+    const text = response.text ?? '';
     console.log('📝 Raw response from Gemini:\n');
     console.log(text);
     console.log('\n');
-    
+
     // Extract JSON from response
     const jsonMatch = text.match(/\[[\s\S]*\]/);
     if (!jsonMatch) {
@@ -477,7 +477,7 @@ Return ONLY a JSON array of ${numVariations} objects with this structure:
       }
     });
     
-    const text = response.text;
+    const text = response.text ?? '';
     const jsonMatch = text.match(/\[[\s\S]*\]/);
     if (!jsonMatch) {
       throw new Error('No JSON found in variations response');

--- a/scripts/generate-page-images.ts
+++ b/scripts/generate-page-images.ts
@@ -264,7 +264,7 @@ async function generatePrompts(
     },
   });
 
-  const text = response.text;
+  const text = response.text ?? '';
   console.log('Raw response from Gemini:\n');
   console.log(text);
   console.log('\n');

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -117,7 +117,7 @@ const itemVariants = {
     y: 0,
     transition: {
       duration: 0.4,
-      ease: [0.22, 1, 0.36, 1],
+      ease: [0.22, 1, 0.36, 1] as const,
     },
   },
 };

--- a/src/app/(teaching)/teaching/level-2/page.tsx
+++ b/src/app/(teaching)/teaching/level-2/page.tsx
@@ -70,7 +70,7 @@ export default function Level2Page() {
             {/* Sacred Space Section */}
             <section className="space-y-8">
               <h2 className="font-serif text-2xl text-[var(--color-foreground)]">
-                {t?.ui.preparingYourSpace ?? 'Preparing Your Space'}
+                {t?.ui.sacredSpace ?? 'Preparing Your Space'}
               </h2>
               {sacredSpaceSlides.map((slide, index) => (
                 <TeachingSlideCard

--- a/src/app/api/pdf/paid-programs/route.ts
+++ b/src/app/api/pdf/paid-programs/route.ts
@@ -1478,7 +1478,7 @@ export async function GET() {
     // =========================================================================
     const pdfBytes = await doc.save();
 
-    return new NextResponse(pdfBytes, {
+    return new NextResponse(Buffer.from(pdfBytes), {
       status: 200,
       headers: {
         'Content-Type': 'application/pdf',

--- a/src/app/api/pdf/summary/route.ts
+++ b/src/app/api/pdf/summary/route.ts
@@ -1407,7 +1407,7 @@ export async function GET() {
     // =========================================================================
     const pdfBytes = await doc.save();
 
-    return new NextResponse(pdfBytes, {
+    return new NextResponse(Buffer.from(pdfBytes), {
       status: 200,
       headers: {
         'Content-Type': 'application/pdf',

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,7 +3,7 @@ export { AnimatedNavText } from './AnimatedNavText';
 export { Button } from './Button';
 export { Card, FeatureCard, Interactive3DCard, PricingCard, TestimonialCard } from './Card';
 export { Navigation } from './Navigation';
-export { Footer, FooterMinimal } from './Footer';
+export { default as Footer, FooterMinimal } from './Footer';
 export { Logo } from './Logo';
 
 // Form Components


### PR DESCRIPTION
## Summary
- Fix framer-motion `ease` type error with `as const` assertion in admin page
- Fix missing i18n key `preparingYourSpace` → use existing `sacredSpace` key
- Fix `Uint8Array` not assignable to `BodyInit` in PDF API routes with `Buffer.from()`
- Fix `Footer` default export / named import mismatch in `ui/index.ts`
- Fix possibly undefined `response.text` in Gemini script helpers

## Test plan
- [ ] `tsc --noEmit` passes cleanly
- [ ] Lint & Type Check CI job passes
- [ ] Vercel deploy succeeds

https://claude.ai/code/session_01SbQrjS3dfjw7HcPmhxpXho