### PR TITLE
Revert community page hero image to generated page image

### DIFF
--- a/src/app/(site)/community/CommunityClient.tsx
+++ b/src/app/(site)/community/CommunityClient.tsx
@@ -317,7 +317,7 @@ export default function CommunityClient() {
         eyebrow="Community"
         title="The Living Field"
         description="A network of practitioners devoted to coherent living. Ongoing gatherings, practices, and programs that nourish the field and support your journey."
-        image="/rose.png"
+        image="/page-images/page-community.png"
       />
 
       {/* 2. Free Activities */}


### PR DESCRIPTION
## Summary
- The community page hero was using `/rose.png` (a simple flat pink icon) instead of `/page-images/page-community.png` (the proper AI-generated rose mandala image)
- Every other page with a hero image uses its corresponding file from `page-images/` — this restores consistency

## Test plan
- [ ] Navigate to `/community` and verify the hero image shows the interconnected roses mandala (matching `page-community.png`)
- [ ] Confirm other pages (e.g. `/contact`, `/guardians`, `/the-rose`) still display their correct hero images

https://claude.ai/code/session_01WBmMWimX1gyM6gDQgHjnbz