### PR TITLE
feat: rename Teaching nav to For Teachers, reorder last, sticky back button

### DIFF
--- a/src/app/(teaching)/teaching/page.tsx
+++ b/src/app/(teaching)/teaching/page.tsx
@@ -21,21 +21,21 @@ export default function TeachingPage() {
 
   return (
     <div className="min-h-screen bg-[var(--color-background)]">
-      <header className="px-6 py-4 border-b border-[var(--color-border)] flex items-center justify-between print:hidden">
+      <header className="sticky top-0 z-30 px-6 py-4 border-b border-[var(--color-border)] bg-[var(--color-background)]/90 backdrop-blur-sm flex items-center justify-between print:hidden">
         <Link
           href="/"
-          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)]"
-        >
-          {t?.ui.rosesOs ?? 'International Aura School'}
-        </Link>
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium text-[var(--color-foreground-muted)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-background-subtle)] transition-all duration-200"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-[var(--color-border)] bg-[var(--color-background-subtle)] text-sm font-medium text-[var(--color-foreground)] hover:bg-[var(--color-background)] hover:border-[var(--color-foreground-muted)] transition-all duration-200"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
           </svg>
           Back to Home
+        </Link>
+        <Link
+          href="/"
+          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)]"
+        >
+          {t?.ui.rosesOs ?? 'International Aura School'}
         </Link>
       </header>
 

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -13,7 +13,6 @@ import { navItems } from '@/lib/data';
 const navLinks = [
   { label: 'Home', href: '/' },
   ...navItems,
-  { label: 'For Teachers', href: '/teaching' },
 ];
 
 // =============================================================================

--- a/src/lib/data/mock-data.ts
+++ b/src/lib/data/mock-data.ts
@@ -17,11 +17,11 @@ import type {
 
 export const navItems: NavItem[] = [
   { label: 'Programs', href: '/offerings' },
-  { label: 'Teaching', href: '/teaching' },
   { label: 'Community', href: '/community' },
   { label: 'About', href: '/the-rose' },
   { label: 'Our Team', href: '/guardians' },
   { label: 'Contact', href: '/contact' },
+  { label: 'For Teachers', href: '/teaching' },
 ];
 
 // =============================================================================


### PR DESCRIPTION
- Move "Teaching" to the end of header navigation and rename to "For Teachers"
- Drop duplicate "For Teachers" entry from footer (now spread once via navItems)
- Make /teaching page header sticky with prominent bordered back button on the left so it stays visible while scrolling

https://claude.ai/code/session_01D2wpCD4dCLoDDXfpJZWxk7