### PR TITLE
fix(header): wrap school name onto two lines

### DIFF
--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -10,6 +10,8 @@ interface LogoProps {
   size?: 'sm' | 'md' | 'lg';
   showText?: boolean;
   textClassName?: string;
+  /** Wrap the school name onto two lines to save horizontal space (e.g. in the header). */
+  twoLine?: boolean;
   onClick?: () => void;
 }
 
@@ -25,6 +27,7 @@ export function Logo({
   size = 'md',
   showText = false,
   textClassName,
+  twoLine = false,
   onClick,
 }: LogoProps) {
   const iconSize = size === 'lg' ? 36 : size === 'md' ? 30 : 24;
@@ -45,7 +48,15 @@ export function Logo({
         )}
         style={{ fontFamily: 'var(--font-sans)' }}
       >
-        International Aura and Dream School
+        {twoLine ? (
+          <>
+            International
+            <br />
+            Aura and Dream School
+          </>
+        ) : (
+          'International Aura and Dream School'
+        )}
       </span>
     </div>
   );

--- a/src/components/ui/Navigation.tsx
+++ b/src/components/ui/Navigation.tsx
@@ -213,7 +213,7 @@ export function Navigation({
                 sits at the start with the nav links beside it. Side-by-side layout so
                 the title is always visible and never overlaps the links at any width. */}
             <div className="z-10 flex items-center min-w-0 flex-1 max-w-[55%] sm:max-w-[60%] md:max-w-none xl:flex-none xl:shrink-0 lg:max-w-none xl:mr-8 2xl:mr-10">
-              {logo || <Logo size="lg" />}
+              {logo || <Logo size="lg" twoLine />}
             </div>
 
             {/* Nav links — fill the space between the logo and the CTA */}


### PR DESCRIPTION
## What
The full wordmark "International Aura and Dream School" crowded the header row. The `Logo` component now takes an optional `twoLine` prop that breaks it as **International** / **Aura and Dream School**, enabled in the public nav header.

## Why
Dario flagged that the long name eats too much horizontal space in the header.

## Verification
- `tsc --noEmit` — no new errors in the edited files
- Screenshots at desktop (1900px) and mobile (390px) confirm clean two-line layout, no overlap with nav links / Begin button / hamburger.

Other logo usages (footer, admin, login) unchanged — still single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)