### PR TITLE
feat(brand): stack school name on two lines across brand labels

### DIFF
--- a/src/app/(forms)/layout.tsx
+++ b/src/app/(forms)/layout.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
+import { stackBrandName } from '@/components/ui/BrandName';
 
 export default function FormsLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-[var(--color-background)]">
       <header className="flex items-center justify-between px-6 py-4 border-b border-[var(--color-border)]">
-        <Link href="/" className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)]">
-          International Aura and Dream School
+        <Link href="/" className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)] leading-tight">
+          {stackBrandName()}
         </Link>
         <Link href="/invitation" className="text-sm text-[var(--color-foreground-muted)] hover:text-[var(--color-foreground)] transition-colors">
           ← Back

--- a/src/app/(invitation)/invitation/page.tsx
+++ b/src/app/(invitation)/invitation/page.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react';
 import { motion, useInView } from 'framer-motion';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { stackBrandName } from '@/components/ui/BrandName';
 
 // =============================================================================
 // SHARED EASE
@@ -33,9 +34,9 @@ function InvitationHero() {
           initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.3, duration: 0.6, ease }}
-          className="text-[11px] font-medium uppercase tracking-[0.2em] text-warm-400 mb-6"
+          className="text-[11px] font-medium uppercase tracking-[0.2em] text-warm-400 mb-6 leading-relaxed"
         >
-          International Aura and Dream School
+          {stackBrandName()}
         </motion.p>
 
         <motion.h1

--- a/src/app/(manuals)/manuals/page.tsx
+++ b/src/app/(manuals)/manuals/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { useManualAuth } from '@/components/manuals/ManualPinGate';
+import { stackBrandName } from '@/components/ui/BrandName';
 import type { Manual } from '@/lib/manuals/types';
 
 export default function ManualsPage() {
@@ -33,9 +34,9 @@ export default function ManualsPage() {
       <header className="px-6 py-4 border-b border-[var(--color-border)] flex items-center justify-between">
         <Link
           href="/"
-          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)]"
+          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)] leading-tight"
         >
-          International Aura and Dream School
+          {stackBrandName()}
         </Link>
         <div className="flex items-center gap-4">
           <span className={cn(

--- a/src/app/(teaching)/teaching/level-1/page.tsx
+++ b/src/app/(teaching)/teaching/level-1/page.tsx
@@ -12,6 +12,7 @@ import { ImageDownloadButton } from '@/components/teaching/ImageDownloadButton';
 import LanguageSelector from '@/components/teaching/LanguageSelector';
 import LevelNavigation from '@/components/teaching/LevelNavigation';
 import EditorLink from '@/components/teaching/EditorLink';
+import { stackBrandName } from '@/components/ui/BrandName';
 import { useLanguage } from '@/lib/i18n';
 
 export default function Level1Page() {
@@ -27,9 +28,9 @@ export default function Level1Page() {
       <header className="flex items-center justify-between px-6 py-4 border-b border-[var(--color-border)]">
         <Link
           href="/"
-          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)]"
+          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)] leading-tight"
         >
-          {t?.ui.rosesOs ?? 'International Aura and Dream School'}
+          {stackBrandName(t?.ui.rosesOs)}
         </Link>
         <div className="flex items-center gap-3">
           <EditorLink manualSlug="rose-meditation-level-1" />

--- a/src/app/(teaching)/teaching/level-2/page.tsx
+++ b/src/app/(teaching)/teaching/level-2/page.tsx
@@ -13,6 +13,7 @@ import { ImageDownloadButton } from '@/components/teaching/ImageDownloadButton';
 import LanguageSelector from '@/components/teaching/LanguageSelector';
 import LevelNavigation from '@/components/teaching/LevelNavigation';
 import EditorLink from '@/components/teaching/EditorLink';
+import { stackBrandName } from '@/components/ui/BrandName';
 import { useLanguage } from '@/lib/i18n';
 
 export default function Level2Page() {
@@ -30,9 +31,9 @@ export default function Level2Page() {
       <header className="flex items-center justify-between px-6 py-4 border-b border-[var(--color-border)]">
         <Link
           href="/"
-          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)]"
+          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)] leading-tight"
         >
-          {t?.ui.rosesOs ?? 'International Aura and Dream School'}
+          {stackBrandName(t?.ui.rosesOs)}
         </Link>
         <div className="flex items-center gap-3">
           <EditorLink manualSlug="rose-meditation-level-2" />

--- a/src/app/(teaching)/teaching/level-3/page.tsx
+++ b/src/app/(teaching)/teaching/level-3/page.tsx
@@ -12,6 +12,7 @@ import { ImageDownloadButton } from '@/components/teaching/ImageDownloadButton';
 import LanguageSelector from '@/components/teaching/LanguageSelector';
 import LevelNavigation from '@/components/teaching/LevelNavigation';
 import EditorLink from '@/components/teaching/EditorLink';
+import { stackBrandName } from '@/components/ui/BrandName';
 import { useLanguage } from '@/lib/i18n';
 
 export default function Level3Page() {
@@ -24,9 +25,9 @@ export default function Level3Page() {
       <header className="flex items-center justify-between px-6 py-4 border-b border-[var(--color-border)]">
         <Link
           href="/"
-          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)]"
+          className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)] leading-tight"
         >
-          {t?.ui.rosesOs ?? 'International Aura and Dream School'}
+          {stackBrandName(t?.ui.rosesOs)}
         </Link>
         <div className="flex items-center gap-3">
           <EditorLink manualSlug="rose-meditation-level-3" />

--- a/src/app/(teaching)/teaching/page.tsx
+++ b/src/app/(teaching)/teaching/page.tsx
@@ -6,6 +6,7 @@ import { openingAgreements, openingImportantToKnow, openingHistory } from '@/lib
 import PrintPageButton from '@/components/teaching/PrintPageButton';
 import LanguageSelector from '@/components/teaching/LanguageSelector';
 import EditorLink from '@/components/teaching/EditorLink';
+import { stackBrandName } from '@/components/ui/BrandName';
 import { useLanguage } from '@/lib/i18n';
 
 export default function TeachingPage() {
@@ -36,9 +37,9 @@ export default function TeachingPage() {
           <EditorLink />
           <Link
             href="/"
-            className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)]"
+            className="font-sans text-sm font-medium tracking-wide uppercase text-[var(--color-foreground)] leading-tight"
           >
-            {t?.ui.rosesOs ?? 'International Aura and Dream School'}
+            {stackBrandName(t?.ui.rosesOs)}
           </Link>
         </div>
       </header>
@@ -53,8 +54,8 @@ export default function TeachingPage() {
             height={72}
             className="object-contain mb-4"
           />
-          <h1 className="font-serif text-4xl md:text-5xl tracking-wide text-[var(--color-foreground)] mb-2">
-            {t?.ui.rosesOs ?? 'International Aura and Dream School'}
+          <h1 className="font-serif text-4xl md:text-5xl tracking-wide text-[var(--color-foreground)] mb-2 leading-tight">
+            {stackBrandName(t?.ui.rosesOs)}
           </h1>
           <p className="text-sm uppercase tracking-widest text-[var(--color-foreground-muted)] mb-6">
             {t?.ui.teacherVisualAidManual ?? 'Teacher Visual Aid Manual'}

--- a/src/components/ui/BrandName.tsx
+++ b/src/components/ui/BrandName.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Canonical school name. Use this single-line string in SEO metadata, prose,
+ * and image alt text — anywhere search engines and screen readers read it.
+ */
+export const BRAND_NAME = 'International Aura and Dream School';
+
+/**
+ * Render the school name as a visual brand label, stacked on two lines:
+ *
+ *   International Aura
+ *   and Dream School
+ *
+ * Only use this where the name appears as a prominent label (header, footer
+ * brand line, hero headings) — not in SEO titles, body prose, or alt text,
+ * which keep the full single-line {@link BRAND_NAME}.
+ *
+ * Accepts an optional (e.g. i18n-resolved) string and breaks it at " and ",
+ * falling back to {@link BRAND_NAME}.
+ */
+export function stackBrandName(name?: string): ReactNode {
+  const value = name ?? BRAND_NAME;
+  const idx = value.indexOf(' and ');
+  if (idx === -1) return value;
+  return (
+    <>
+      {value.slice(0, idx)}
+      <br />
+      {value.slice(idx + 1)}
+    </>
+  );
+}

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { motion, useInView } from 'framer-motion';
 import { navItems } from '@/lib/data';
+import { stackBrandName } from './BrandName';
 
 // =============================================================================
 // DATA
@@ -40,7 +41,7 @@ export default function Footer() {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-10 lg:gap-8 pb-10 border-b border-warm-800 dark:border-warm-200">
             {/* Col 1: Brand */}
             <div className="sm:col-span-2 lg:col-span-1">
-              <p className="font-serif text-xl text-white dark:text-warm-900 mb-3">International Aura and Dream School</p>
+              <p className="font-serif text-xl text-white dark:text-warm-900 mb-3 leading-tight">{stackBrandName()}</p>
               <p className="text-sm text-warm-500 dark:text-warm-400 leading-relaxed max-w-xs">
                 A living operating system for spiritual development. Rose Meditation, Aura Reading, and the journey to coherent living.
               </p>

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
+import { BRAND_NAME, stackBrandName } from './BrandName';
 
 interface LogoProps {
   href?: string;
@@ -48,15 +49,7 @@ export function Logo({
         )}
         style={{ fontFamily: 'var(--font-sans)' }}
       >
-        {twoLine ? (
-          <>
-            International
-            <br />
-            Aura and Dream School
-          </>
-        ) : (
-          'International Aura and Dream School'
-        )}
+        {twoLine ? stackBrandName() : BRAND_NAME}
       </span>
     </div>
   );


### PR DESCRIPTION
## What
Follow-up to #619. The header break is now **International Aura** / **and Dream School** (per Dario), and the same two-line model is applied across the prominent brand-label surfaces via a shared `stackBrandName()` helper.

**Stacked (visual brand labels):** header logo, footer brand line, forms/manuals/teaching header links, teaching hero h1, level 1-3 headers, invitation hero eyebrow.

**Left as full single-line name (on purpose):** SEO titles/descriptions/JSON-LD, body prose, image `alt` text, footer copyright micro-line, invitation back pill, and the "What is …" question eyebrow. Changing those would hurt search ranking or read awkwardly.

The i18n `rosesOs` value is preserved — passed through the helper, broken at `" and "`.

## Verification
- `tsc --noEmit` — no new errors in edited files (only the pre-existing `jszip` issue in `ImageDownloadButton`).
- DOM confirms `International Aura<br>and Dream School` in the header span.
- Screenshots: home header + footer render correctly (two-line brand line, one-line copyright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)