### PR TITLE
feat(manuals): level-specific download button label

### DIFF
--- a/src/lib/data/manual-pdf-paths.ts
+++ b/src/lib/data/manual-pdf-paths.ts
@@ -14,6 +14,25 @@ export interface ManualPdfConfig {
   labels: Partial<Record<Locale, string>>;
 }
 
+/**
+ * Per-locale label builders for the per-level student manual button.
+ * Each embeds the level number so the button reads e.g. "Baixar Manual do Nível 3"
+ * instead of a generic "Baixar Manual do Estudante" repeated across every level.
+ * Locales without a builder (ru, uk) fall back to the English label in the button.
+ */
+const manualLabelBuilders: Partial<Record<Locale, (level: number) => string>> = {
+  en: (level) => `Download Level ${level} Manual`,
+  es: (level) => `Descargar Manual del Nivel ${level}`,
+  pt: (level) => `Baixar Manual do Nível ${level}`,
+  el: (level) => `Λήψη Εγχειριδίου Επιπέδου ${level}`,
+};
+
+function manualLabels(level: number): Partial<Record<Locale, string>> {
+  return Object.fromEntries(
+    Object.entries(manualLabelBuilders).map(([locale, build]) => [locale, build(level)]),
+  ) as Partial<Record<Locale, string>>;
+}
+
 export const manualPdfConfigs: ManualPdfConfig[] = [
   {
     level: 1,
@@ -23,12 +42,7 @@ export const manualPdfConfigs: ManualPdfConfig[] = [
       pt: '/resources/manuals/Rose-Level-1-Manual-PT.pdf',
       el: '/resources/manuals/Rose-Level-1-Manual-EL.pdf',
     },
-    labels: {
-      en: 'Download Student Manual',
-      es: 'Descargar Manual del Estudiante',
-      pt: 'Baixar Manual do Estudante',
-      el: 'Λήψη Εγχειριδίου Μαθητή',
-    },
+    labels: manualLabels(1),
   },
   {
     level: 2,
@@ -37,12 +51,7 @@ export const manualPdfConfigs: ManualPdfConfig[] = [
       es: '/resources/manuals/Rose-Level-2-Manual-ES.pdf',
       pt: '/resources/manuals/Rose-Level-2-Manual-PT.pdf',
     },
-    labels: {
-      en: 'Download Student Manual',
-      es: 'Descargar Manual del Estudiante',
-      pt: 'Baixar Manual do Estudante',
-      el: 'Λήψη Εγχειριδίου Μαθητή',
-    },
+    labels: manualLabels(2),
   },
   {
     level: 3,
@@ -51,12 +60,7 @@ export const manualPdfConfigs: ManualPdfConfig[] = [
       es: '/resources/manuals/Rose-Level-3-Manual-ES.pdf',
       pt: '/resources/manuals/Rose-Level-3-Manual-PT.pdf',
     },
-    labels: {
-      en: 'Download Student Manual',
-      es: 'Descargar Manual del Estudiante',
-      pt: 'Baixar Manual do Estudante',
-      el: 'Λήψη Εγχειριδίου Μαθητή',
-    },
+    labels: manualLabels(3),
   },
 ];
 


### PR DESCRIPTION
## What
The student-manual download button showed the same generic label on every level (`Baixar Manual do Estudante`), differing only by language, not by level. Labels are now built from a per-locale template that embeds the level number:

- PT: **Baixar Manual do Nível 3**
- ES: **Descargar Manual del Nivel 3**
- EN: **Download Level 3 Manual**
- EL: **Λήψη Εγχειριδίου Επιπέδου 3**

Wording lives in one place (`manualLabelBuilders` in `manual-pdf-paths.ts`). `ru`/`uk` (no manual content) fall back to the English label, same as the rest of the site.

## Verification
- `tsc --noEmit` — clean for the edited file.
- Live verification on prod after deploy (pages are PIN-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)