### PR TITLE
fix(manuals): Draft PDF button works on Vercel (@sparticuz/chromium)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,10 @@ const nextConfig: NextConfig = {
     // Pre-existing type error in admin/page.tsx (framer-motion Variants typing)
     ignoreBuildErrors: true,
   },
-  serverExternalPackages: ['sharp'],
+  // sharp: native image lib. @sparticuz/chromium: ships a brotli-compressed
+  // Chromium the draft-PDF route unpacks at runtime — must stay external so its
+  // binary is traced into the serverless function rather than bundled.
+  serverExternalPackages: ['sharp', '@sparticuz/chromium'],
   async redirects() {
     return [
       // Manual PDFs were renamed from ROSES-OS-Level-* to Rose-Level-* (commit 2dddb20)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@react-three/postprocessing": "^3.0.4",
+    "@sparticuz/chromium": "^149.0.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.90.1",
     "@tiptap/pm": "^3.23.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@react-three/postprocessing':
         specifier: ^3.0.4
         version: 3.0.4(@react-three/fiber@9.5.0(@types/react@19.2.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(three@0.182.0))(@types/three@0.182.0)(react@19.2.3)(three@0.182.0)
+      '@sparticuz/chromium':
+        specifier: ^149.0.0
+        version: 149.0.0
       '@supabase/ssr':
         specifier: ^0.8.0
         version: 0.8.0(@supabase/supabase-js@2.95.3)
@@ -649,6 +652,10 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sparticuz/chromium@149.0.0':
+    resolution: {integrity: sha512-2NECBVKlUA9xIUXb4fT8OoGKdAJs+I2tNYscO8FwcxCKCWA7FmpPI0fdVxGJoIJglrFZYn+4YEJqChq4rdrxQg==}
+    engines: {node: ^22.17.0 || >=24.0.0}
 
   '@supabase/auth-js@2.95.3':
     resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
@@ -3984,6 +3991,14 @@ snapshots:
       - '@types/three'
 
   '@rtsao/scc@1.1.0': {}
+
+  '@sparticuz/chromium@149.0.0':
+    dependencies:
+      tar-fs: 3.1.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   '@supabase/auth-js@2.95.3':
     dependencies:

--- a/src/lib/manuals/draft-pdf.ts
+++ b/src/lib/manuals/draft-pdf.ts
@@ -57,6 +57,41 @@ export function resolveChromeExecutable(): string {
   );
 }
 
+/** True when running inside a Vercel / AWS Lambda serverless function, where no
+ *  system Chrome exists and we must supply the bundled @sparticuz/chromium. */
+function isServerless(): boolean {
+  return Boolean(
+    process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME || process.env.AWS_EXECUTION_ENV,
+  );
+}
+
+/** Launch options for puppeteer-core. On a serverless host with no explicit
+ *  executable override, use the bundled @sparticuz/chromium (its own args +
+ *  runtime-extracted binary). Otherwise resolve a local/explicit Chrome. */
+async function resolveLaunchOptions(): Promise<{
+  executablePath: string;
+  args: string[];
+  headless: boolean;
+}> {
+  const explicit = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.CHROME_PATH;
+  if (!explicit && isServerless()) {
+    const chromium = (await import('@sparticuz/chromium')).default;
+    // The manual renders plain HTML + images; no WebGL, so disable the graphics
+    // stack (skips the swiftshader extraction — smaller/faster cold start).
+    chromium.setGraphicsMode = false;
+    return {
+      executablePath: await chromium.executablePath(),
+      args: chromium.args,
+      headless: true,
+    };
+  }
+  return {
+    executablePath: resolveChromeExecutable(),
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    headless: true,
+  };
+}
+
 /**
  * Render the current blocks to a draft PDF (Buffer). Pure of any storage; the
  * caller (the API route) sets the response headers. `origin` resolves
@@ -64,15 +99,12 @@ export function resolveChromeExecutable(): string {
  */
 export async function blocksToPdf(blocks: ManualBlock[], title: string, origin = ''): Promise<Buffer> {
   const html = blocksToHtml(blocks, title, origin);
-  const executablePath = resolveChromeExecutable();
   // puppeteer-core is the only Puppeteer package installed; it needs an external
-  // executable, which resolveChromeExecutable provides.
+  // executable. On Vercel that comes from the bundled @sparticuz/chromium; locally
+  // from a resolved system Chrome. See resolveLaunchOptions.
+  const { executablePath, args, headless } = await resolveLaunchOptions();
   const puppeteer = (await import('puppeteer-core')).default;
-  const browser = await puppeteer.launch({
-    executablePath,
-    headless: true,
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
-  });
+  const browser = await puppeteer.launch({ executablePath, headless, args });
   try {
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'networkidle0', timeout: 30000 });


### PR DESCRIPTION
The **"Draft PDF from your edits"** button returned 500 `NO_CHROME` in production — confirmed live:
```
POST /api/manuals/*/draft-pdf → 500 {"code":"NO_CHROME"}
```
The route launches puppeteer-core, which needs a Chrome binary; Vercel's serverless runtime has none. The route's own comment already pointed at the fix.

## Fix
- Add **@sparticuz/chromium** (serverless Chromium) + mark it `serverExternalPackages` so its binary is traced into the function.
- `draft-pdf.ts` resolves the launcher by env: explicit `PUPPETEER_EXECUTABLE_PATH` wins → else serverless (VERCEL/Lambda) uses bundled @sparticuz/chromium (graphics stack off) → else local system Chrome.

## Verified
- Local render: 33KB valid PDF (`%PDF` header) via the explicit-path branch.
- tsc + eslint clean.
- Serverless path validated on the Vercel deploy (see comment after build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)