### PR TITLE
fix(manuals): trace @sparticuz/chromium bin into draft-PDF function

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -49,6 +49,17 @@ const nextConfig: NextConfig = {
       './public/models/**',
     ],
   },
+  outputFileTracingIncludes: {
+    // @sparticuz/chromium reads its brotli-packed binary from its own bin/ dir at
+    // runtime (fs, not require), so Next's tracer doesn't pull those files into the
+    // function. Without this the draft-PDF route throws "input directory .../bin
+    // does not exist". Force the bin/ into that function. The key is a glob (no
+    // literal [manualId] brackets — picomatch would read them as a char class).
+    '/api/manuals/**': [
+      './node_modules/.pnpm/@sparticuz+chromium@*/node_modules/@sparticuz/chromium/bin/**',
+      './node_modules/@sparticuz/chromium/bin/**',
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Follow-up to #654. That fix deployed but the route threw at runtime:
```
PDF_FAILED: input directory .../@sparticuz/chromium/bin does not exist
```
@sparticuz reads its brotli binary from `bin/` via fs at runtime, so Next's file tracer (require/import graph only) never pulled those assets into the function.

**Fix:** `outputFileTracingIncludes` for `/api/manuals/**` pointing at the chromium `bin/` (both the pnpm real path and the symlink). Config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)