### PR TITLE
fix(manuals): image blocks carry a width so ornaments render small

### DIFF
--- a/src/components/manuals/PreviewPane.tsx
+++ b/src/components/manuals/PreviewPane.tsx
@@ -93,12 +93,17 @@ function PreviewBlockRow({ block }: { block: ManualBlock }) {
     }
     case 'image':
     case 'captioned-figure': {
-      const c = block.content as { src: string; alt: string; caption?: string };
+      const c = block.content as { src: string; alt: string; caption?: string; width_pct?: number };
       if (!c.src) return null;
+      // Honor width_pct so a small ornament previews small, matching the editor
+      // and the exported PDF.
+      const pct = typeof c.width_pct === 'number'
+        ? Math.min(100, Math.max(2, c.width_pct))
+        : undefined;
       return (
         <figure>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={c.src} alt={c.alt} />
+          <img src={c.src} alt={c.alt} style={pct !== undefined ? { width: `${pct}%`, height: 'auto' } : undefined} />
           {c.caption ? <figcaption>{c.caption}</figcaption> : null}
         </figure>
       );

--- a/src/components/manuals/blocks/ImageBlock.tsx
+++ b/src/components/manuals/blocks/ImageBlock.tsx
@@ -112,10 +112,25 @@ export default function ImageBlock({ content, onChange, readOnly }: ImageBlockPr
     );
   }
 
-  // Image with caption
+  // Image with caption. An explicit width_pct constrains the rendered width so a
+  // small decorative ornament shows small — in the editor and, via export-html,
+  // in the downloaded PDF. Omitted → full content-column width (prior behavior).
+  const widthPct = typeof content.width_pct === 'number'
+    ? Math.min(100, Math.max(2, content.width_pct))
+    : undefined;
+  const sizePresets: { label: string; pct: number }[] = [
+    { label: 'S', pct: 15 },
+    { label: 'M', pct: 40 },
+    { label: 'L', pct: 70 },
+    { label: 'Full', pct: 100 },
+  ];
+
   return (
     <div className="group/img relative">
-      <div className="rounded-xl overflow-hidden bg-[var(--color-background-muted)] mx-auto w-full max-w-prose">
+      <div
+        className="rounded-xl overflow-hidden bg-[var(--color-background-muted)] mx-auto w-full max-w-prose"
+        style={widthPct !== undefined ? { width: `${widthPct}%` } : undefined}
+      >
         <img
           src={content.src}
           alt={content.alt || ''}
@@ -144,9 +159,29 @@ export default function ImageBlock({ content, onChange, readOnly }: ImageBlockPr
         </div>
       )}
 
-      {/* Replace / alt text controls */}
+      {/* Size + replace controls */}
       {!readOnly && (
         <div className="absolute top-3 right-3 flex gap-2 opacity-0 group-hover/img:opacity-100 transition-opacity">
+          <div className="flex items-center rounded-lg bg-black/60 backdrop-blur-sm shadow-sm overflow-hidden" role="group" aria-label="Image size">
+            {sizePresets.map((p) => {
+              const active = p.pct === 100 ? widthPct === undefined || widthPct === 100 : widthPct === p.pct;
+              return (
+                <button
+                  key={p.label}
+                  type="button"
+                  onClick={() => onChange({ ...content, width_pct: p.pct })}
+                  aria-pressed={active}
+                  title={`${p.pct}% width`}
+                  className={cn(
+                    'text-xs px-2.5 py-1.5 transition-colors',
+                    active ? 'bg-white/25 text-white font-semibold' : 'text-white/80 hover:bg-white/15'
+                  )}
+                >
+                  {p.label}
+                </button>
+              );
+            })}
+          </div>
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}

--- a/src/lib/manuals/block-schema.ts
+++ b/src/lib/manuals/block-schema.ts
@@ -69,6 +69,7 @@ export const imageContentSchema = z.object({
   src: z.string(),
   alt: z.string(),
   caption: z.string().optional(),
+  width_pct: z.number().min(2).max(100).optional(),
 });
 
 export const imageRowContentSchema = z.object({

--- a/src/lib/manuals/export-html.ts
+++ b/src/lib/manuals/export-html.ts
@@ -91,7 +91,12 @@ export function blocksToHtml(blocks: ManualBlock[], title: string, origin = ''):
       case 'image': {
         const c = block.content as ImageContent;
         if (!c.src) return '';
-        return `<figure class="figure">${imgTag(c.src, c.alt, 'width:80%;border-radius:12px;')}${c.caption ? `<figcaption>${esc(c.caption)}</figcaption>` : ''}</figure>`;
+        // Honor an explicit width_pct so a small decorative ornament renders small
+        // instead of the flat 80% default (matches captioned-figure behavior).
+        const pct = typeof c.width_pct === 'number'
+          ? Math.min(100, Math.max(2, c.width_pct))
+          : 80;
+        return `<figure class="figure">${imgTag(c.src, c.alt, `width:${pct}%;height:auto;border-radius:12px;`)}${c.caption ? `<figcaption>${esc(c.caption)}</figcaption>` : ''}</figure>`;
       }
       case 'captioned-figure': {
         const c = block.content as CaptionedFigureContent;

--- a/src/lib/manuals/types.ts
+++ b/src/lib/manuals/types.ts
@@ -70,6 +70,10 @@ export interface ImageContent {
   src: string;
   alt: string;
   caption?: string;
+  /** Rendered width as a percentage of the content column (2–100). Lets a small
+   *  decorative ornament render small in both the editor and the exported PDF
+   *  instead of the flat full/80% default. Omitted → default width. */
+  width_pct?: number;
 }
 
 export interface ImageRowItem {


### PR DESCRIPTION
## Problem

The decorative blue rose on the contents page is an `image` block. Image blocks had **no size control**, so the small ornament rendered huge:

- **Editor**: prose width, capped only at 420px tall → a near-full-page rose.
- **Downloaded edits** (HTML/print-to-PDF): a flat `width:80%` → a full-page rose.

This happened in **every language** because the ornament exists once per language per manual.

| | Canonical (correct) | Editor / download (bug) |
|---|---|---|
| Rose | small ornament above the contents list | balloons to a full page |

## Fix

- Add optional `width_pct` (2–100) to `ImageContent` and its zod schema — mirrors what `captioned-figure` already does.
- Honor it in all three render paths: the editor (`ImageBlock`), the live preview (`PreviewPane`), and the HTML/PDF export (`export-html`). One width, rendered consistently everywhere.
- Add **S / M / L / Full** size presets to the image block's hover toolbar, so any image can be resized directly in the editor (this is the general fix behind "the editing page isn't working well").

## Data

The 19 rose-ornament blocks — L1/L2/L3 + staging, all 6 languages (en/es/pt/el/ru/uk) — are set to `width_pct: 12` via a Supabase patch. Verified: all 19 now carry the value; none missing.

## Verification

- `pnpm type-check` clean for `src/` (pre-existing errors are only in the vendored `_qie/` observability templates; eslint's plugin install is broken in the local env, unrelated to this diff).
- Data patch verified by re-fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)