### PR TITLE
fix(manuals): cover shows the image (not its URL) + restore missing front matter

### DIFF
--- a/src/components/manuals/PreviewPane.tsx
+++ b/src/components/manuals/PreviewPane.tsx
@@ -139,12 +139,15 @@ function PreviewBlockRow({ block }: { block: ManualBlock }) {
       return <blockquote>{c.attribution ? `— ${c.attribution}` : '“…”'}</blockquote>;
     }
     case 'cover': {
-      const c = block.content as { title: string; author?: string; illustrator?: string };
+      const c = block.content as { title: string; author?: string; illustrator?: string; credits?: string; edition?: string; notice?: string };
       return (
         <div className="text-center">
           <h1>{c.title}</h1>
           {c.author ? <p>By {c.author}</p> : null}
           {c.illustrator ? <p style={{ fontStyle: 'italic' }}>Illustrated by {c.illustrator}</p> : null}
+          {c.credits ? c.credits.split('\n').map((line, i) => <p key={i} style={{ fontSize: '0.72rem' }}>{line}</p>) : null}
+          {c.edition ? <p style={{ fontSize: '0.65rem', letterSpacing: '0.2em', textTransform: 'uppercase' }}>{c.edition}</p> : null}
+          {c.notice ? <p style={{ maxWidth: '30rem', margin: '1rem auto 0', fontSize: '0.65rem', fontStyle: 'italic' }}>{c.notice}</p> : null}
         </div>
       );
     }

--- a/src/components/manuals/blocks/CoverBlock/index.tsx
+++ b/src/components/manuals/blocks/CoverBlock/index.tsx
@@ -113,12 +113,21 @@ export default function CoverBlock({ content, onChange, readOnly }: Props) {
         className="block mx-auto mt-2 w-2/3 text-base italic font-serif text-rose-700 text-center bg-transparent border-b border-stone-300 px-0 py-1 focus:outline-none"
         aria-label="Cover subtitle"
       />
+      {content.cover_image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={content.cover_image}
+          alt=""
+          className="block mx-auto mt-4 mb-1"
+          style={{ maxWidth: '180px' }}
+        />
+      ) : null}
       <input
         type="text"
         value={content.cover_image ?? ''}
         onChange={(e) => onChange({ ...content, cover_image: e.target.value })}
         placeholder="Cover image URL (optional)"
-        className="block mx-auto my-3 w-3/4 text-xs bg-transparent border-b border-stone-300 px-0 py-1 text-center focus:outline-none"
+        className="block mx-auto my-2 w-3/4 text-xs text-stone-400 bg-transparent border-b border-stone-300 px-0 py-1 text-center focus:outline-none"
         aria-label="Cover image URL"
       />
       <input

--- a/src/components/manuals/blocks/CoverBlock/index.tsx
+++ b/src/components/manuals/blocks/CoverBlock/index.tsx
@@ -82,6 +82,23 @@ export default function CoverBlock({ content, onChange, readOnly }: Props) {
           {content.author ? <p style={{ margin: 0 }}>By {content.author}</p> : null}
           {content.illustrator ? <p style={{ margin: 0, fontStyle: 'italic' }}>Illustrated by {content.illustrator}</p> : null}
         </div>
+        {content.credits ? (
+          <div style={{ marginTop: '0.75rem', fontFamily: typography.fonts.sans, fontSize: '0.72rem', lineHeight: 1.8, color: typography.palette.terracotta, opacity: 0.85 }}>
+            {content.credits.split('\n').map((line, i) => (
+              <p key={i} style={{ margin: 0 }}>{line}</p>
+            ))}
+          </div>
+        ) : null}
+        {content.edition ? (
+          <div style={{ marginTop: '0.75rem', fontFamily: typography.fonts.sans, fontSize: '0.65rem', letterSpacing: '0.2em', textTransform: 'uppercase', color: typography.palette.terracotta, opacity: 0.8 }}>
+            {content.edition}
+          </div>
+        ) : null}
+        {content.notice ? (
+          <p style={{ maxWidth: '30rem', margin: '1.5rem auto 0', fontFamily: typography.fonts.sans, fontSize: '0.65rem', fontStyle: 'italic', lineHeight: 1.6, color: typography.palette.terracotta, opacity: 0.75 }}>
+            {content.notice}
+          </p>
+        ) : null}
       </div>
     );
   }
@@ -145,6 +162,30 @@ export default function CoverBlock({ content, onChange, readOnly }: Props) {
         placeholder="Illustrator (optional)"
         className="block mx-auto w-2/3 text-sm bg-transparent border-b border-stone-300 px-0 py-1 italic text-center focus:outline-none"
         aria-label="Cover illustrator"
+      />
+      <textarea
+        value={content.credits ?? ''}
+        onChange={(e) => onChange({ ...content, credits: e.target.value })}
+        placeholder="Credits (one line each: illustrations, editor, design)"
+        rows={2}
+        className="block mx-auto mt-3 w-3/4 text-xs text-stone-500 bg-transparent border-b border-stone-300 px-0 py-1 text-center focus:outline-none resize-none"
+        aria-label="Cover credits"
+      />
+      <input
+        type="text"
+        value={content.edition ?? ''}
+        onChange={(e) => onChange({ ...content, edition: e.target.value })}
+        placeholder="Edition (optional)"
+        className="block mx-auto mt-2 w-2/3 text-xs uppercase tracking-[0.2em] text-stone-500 bg-transparent border-b border-stone-300 px-0 py-1 text-center focus:outline-none"
+        aria-label="Cover edition"
+      />
+      <textarea
+        value={content.notice ?? ''}
+        onChange={(e) => onChange({ ...content, notice: e.target.value })}
+        placeholder="Protection notice (optional)"
+        rows={3}
+        className="block mx-auto mt-3 w-3/4 text-xs italic text-stone-400 bg-transparent border-b border-stone-300 px-0 py-1 text-center focus:outline-none resize-none"
+        aria-label="Cover protection notice"
       />
     </div>
   );

--- a/src/lib/manuals/block-schema.ts
+++ b/src/lib/manuals/block-schema.ts
@@ -95,6 +95,9 @@ export const coverContentSchema = z.object({
   illustrator: z.string().optional(),
   cover_image: z.string().optional(),
   eyebrow: z.string().optional(),
+  credits: z.string().optional(),
+  edition: z.string().optional(),
+  notice: z.string().optional(),
 });
 
 export const contentsRowSchema = z.object({

--- a/src/lib/manuals/export-html.ts
+++ b/src/lib/manuals/export-html.ts
@@ -125,6 +125,9 @@ export function blocksToHtml(blocks: ManualBlock[], title: string, origin = ''):
           + (c.subtitle ? `<div class="cover-subtitle">${esc(c.subtitle)}</div>` : '')
           + (c.author ? `<div class="cover-credit">${esc(c.author)}</div>` : '')
           + (c.illustrator ? `<div class="cover-credit"><em>Illustrated by ${esc(c.illustrator)}</em></div>` : '')
+          + (c.credits ? `<div class="cover-credit">${esc(c.credits).replace(/\n/g, '<br>')}</div>` : '')
+          + (c.edition ? `<div class="cover-credit" style="letter-spacing:0.2em;text-transform:uppercase;font-size:0.7em;">${esc(c.edition)}</div>` : '')
+          + (c.notice ? `<div class="cover-credit" style="max-width:30rem;margin:1.25rem auto 0;font-style:italic;font-size:0.72em;line-height:1.6;opacity:0.8;">${esc(c.notice)}</div>` : '')
           + `</div>`;
       }
       case 'callout': {

--- a/src/lib/manuals/translate-fields.ts
+++ b/src/lib/manuals/translate-fields.ts
@@ -114,7 +114,7 @@ export function collectStrings(blockType: string, content: unknown): FieldString
       break;
     }
     case 'cover':
-      for (const k of ['title', 'subtitle', 'author', 'illustrator', 'eyebrow']) pushIfStr(c, [k], 'plain', out);
+      for (const k of ['title', 'subtitle', 'author', 'illustrator', 'eyebrow', 'credits', 'edition', 'notice']) pushIfStr(c, [k], 'plain', out);
       break;
     case 'contents': {
       pushIfStr(c, ['eyebrow'], 'plain', out);

--- a/src/lib/manuals/types.ts
+++ b/src/lib/manuals/types.ts
@@ -103,6 +103,13 @@ export interface CoverContent {
   cover_image?: string;
   /** Small eyebrow line above the title (e.g., "ROSES OS · LEVEL 1"). */
   eyebrow?: string;
+  /** Front-matter credits below the author, one line per newline (e.g.
+   *  illustrations, editor, design). Restores the printed cover's credit block. */
+  credits?: string;
+  /** Edition line (e.g., "2026 · Review Edition"). */
+  edition?: string;
+  /** Protection / do-not-share notice printed at the foot of the cover page. */
+  notice?: string;
 }
 
 /** A single table-of-contents row: numeral | title | page. */


### PR DESCRIPTION
Two cover-page issues on the first page of the editor, both fixed.

## 1. Cover image showed as a URL, not an image
The cover block's **edit mode** rendered `cover_image` only as a text input holding the path (e.g. `/rose med images/manual-l1-cover.png`). So the editor's first page showed the image's URL instead of the image. Read view was already correct.

Fix: render an image preview above the URL field when a cover image is set; keep the URL editable (muted) below it.

## 2. Missing front matter on the first page
The printed cover carries a full front-matter block that geometry reconstruction dropped — the cover block only held title/subtitle/author/image. Missing in **every language**:
- School name (→ now the cover `eyebrow`)
- Illustrations credit
- Editor / Design credit
- Edition line ("2026 · Review Edition")
- Protection / do-not-share notice

Fix: add optional `credits`, `edition`, `notice` to `CoverContent` + schema, rendered in the editor, the live preview (`PreviewPane`), and the HTML/PDF export (`export-html`). `translate-fields` now collects them so future re-translation covers them.

### Data
Cover rows for all 3 manuals × all 6 languages (en/es/pt/el/ru/uk) populated from the canonical front matter. EN/ES/PT/RU/UK come verbatim from the canonical HTML; **Greek (el)** had no canonical source so it's a faithful translation (illustrator/editor names kept Latin). Staging covers patched too, so a future promote won't wipe it. Verified: all 18 prod covers carry the four fields.

## Verification
- `pnpm type-check` clean for `src/`.
- DB migration verified by re-fetch (18/18 covers populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)